### PR TITLE
Fix CircleCI build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,14 +32,15 @@ jobs:
           # fallback to using the latest cache if no exact match is found
           - v1-dependencies-
 
-      - run: npm install
-
       # Remove the mocha type references in @opencensus/core. This has been
       # fixed in the upstream package on GitHub, but has not been released on
       # NPM yet. We can't install the package directly from GitHub because NPM
       # only supports that for packages in the root folder of the repo.
       # See https://github.com/census-instrumentation/opencensus-node/pull/254
+      - run: (cd packages/opencensus-web-exporter-ocagent && npm install || true)
       - run: find . -type f | grep '@opencensus/core' | xargs sed -i '/types="mocha"/d'
+
+      - run: npm install
 
       - save_cache:
           paths:


### PR DESCRIPTION
The workaround for the `mocha` types needed to be moved before the main `npm install` and a `npm install` for just the exporter package was needed first.