### PR TITLE
Support high-res performance times in ocagent exporter

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,18 +37,10 @@ jobs:
       # NPM yet. We can't install the package directly from GitHub because NPM
       # only supports that for packages in the root folder of the repo.
       # See https://github.com/census-instrumentation/opencensus-node/pull/254
-      - run: (cd packages/opencensus-web-core && npm install || true)
-      - run: (cd packages/opencensus-web-exporter-ocagent && npm install || true)
+      - run: npm install || true
       - run: find . -type f | grep '@opencensus/core' | xargs sed -i '/types="mocha"/d'
 
       - run: npm install
-
-      # Remove the mocha type references in @opencensus/core. This has been
-      # fixed in the upstream package on GitHub, but has not been released on
-      # NPM yet. We can't install the package directly from GitHub because NPM
-      # only supports that for packages in the root folder of the repo.
-      # See https://github.com/census-instrumentation/opencensus-node/pull/254
-      - run: find . -type f | grep '@opencensus/core' | xargs sed -i '/types="mocha"/d'
 
       - save_cache:
           paths:

--- a/packages/opencensus-web-core/package-lock.json
+++ b/packages/opencensus-web-core/package-lock.json
@@ -4037,6 +4037,7 @@
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
       "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
       "dev": true,
+      "optional": true,
       "requires": {
         "safe-buffer": "^5.1.2",
         "yallist": "^3.0.0"
@@ -4046,7 +4047,8 @@
           "version": "3.0.3",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
           "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/packages/opencensus-web-core/package.json
+++ b/packages/opencensus-web-core/package.json
@@ -1,8 +1,7 @@
 {
   "name": "@opencensus/web-core",
   "version": "0.0.1",
-  "description":
-    "OpenCensus Web is a toolkit for collecting application performance and behavior data from client side web browser apps.",
+  "description": "OpenCensus Web is a toolkit for collecting application performance and behavior data from client side web browser apps.",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
   "scripts": {

--- a/packages/opencensus-web-core/src/common/time-util.ts
+++ b/packages/opencensus-web-core/src/common/time-util.ts
@@ -29,3 +29,33 @@ export function getPerfTimeOrigin(): number {
 export function getDateForPerfTime(perfTime: DOMHighResTimeStamp): Date {
   return new Date(getPerfTimeOrigin() + perfTime);
 }
+
+/**
+ * Converts a time in browser performance clock milliseconds into a nanosecond
+ * precision ISO date string.
+ */
+export function getIsoDateStrForPerfTime(perfTime: number): string {
+  // Break origin and perf times into whole and fractional parts.
+  const [originWhole, originFrac] = wholeAndFraction(getPerfTimeOrigin());
+  const [perfWhole, perfFrac] = wholeAndFraction(perfTime);
+
+  // Combine the fractional and whole parts separately to preserve precision.
+  const totalFrac = originFrac + perfFrac;
+  const [extraWholeMs, fracMs] = wholeAndFraction(totalFrac);
+  const wholeMs = originWhole + perfWhole + extraWholeMs;
+
+  // Use native Date class to get ISO string for the whole number milliseconds.
+  const dateStrWholeMs = new Date(wholeMs).toISOString();
+
+  // Append the fractional millisecond for the final 6 digits of the ISO date.
+  const dateStrWithoutZ = dateStrWholeMs.replace('Z', '');
+  const millisFracStr = fracMs.toFixed(6).substring(2);
+  return `${dateStrWithoutZ}${millisFracStr}Z`;
+}
+
+/** Splits a number into whole and fractional parts. */
+function wholeAndFraction(num: number): [number, number] {
+  const whole = Math.floor(num);
+  const fraction = num - whole;
+  return [whole, fraction];
+}

--- a/packages/opencensus-web-core/src/index.ts
+++ b/packages/opencensus-web-core/src/index.ts
@@ -23,3 +23,5 @@ export * from './trace/model/types';
 
 // Re-export types this uses from @opencensus/core.
 export {Annotation, Attributes, Link, MessageEvent, SpanContext, SpanEventListener, TraceState, Propagation, Exporter, TracerConfig, Config} from '@opencensus/core';
+
+export * from './common/time-util';

--- a/packages/opencensus-web-core/test/test-time-util.ts
+++ b/packages/opencensus-web-core/test/test-time-util.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {getDateForPerfTime, getPerfTimeOrigin} from '../src/common/time-util';
+import {getDateForPerfTime, getIsoDateStrForPerfTime, getPerfTimeOrigin} from '../src/common/time-util';
 
 describe('getPerfTimeOrigin', () => {
   it('returns `performance.timeOrigin` if set', () => {
@@ -37,5 +37,20 @@ describe('getDateForPerfTime', () => {
     spyOnProperty(performance, 'timeOrigin').and.returnValue(1548000000000);
 
     expect(getDateForPerfTime(999.6).getTime()).toBe(1548000000999);
+  });
+});
+
+describe('getIsoDateStrForPerfTime', () => {
+  it('converts perf time to nanosecond-precise ISO date string', () => {
+    spyOnProperty(performance, 'timeOrigin').and.returnValue(1535683887001);
+    expect(getIsoDateStrForPerfTime(0.000001))
+        .toEqual('2018-08-31T02:51:27.001000001Z');
+  });
+
+  it('accurately combines milliseconds from origin and perf times', () => {
+    spyOnProperty(performance, 'timeOrigin').and.returnValue(1535683887441.586);
+
+    expect(getIsoDateStrForPerfTime(658867.8000000073))
+        .toEqual('2018-08-31T03:02:26.309385938Z');
   });
 });

--- a/packages/opencensus-web-exporter-ocagent/package-lock.json
+++ b/packages/opencensus-web-exporter-ocagent/package-lock.json
@@ -4037,6 +4037,7 @@
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
       "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
       "dev": true,
+      "optional": true,
       "requires": {
         "safe-buffer": "^5.1.2",
         "yallist": "^3.0.0"
@@ -4046,7 +4047,8 @@
           "version": "3.0.3",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
           "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/packages/opencensus-web-exporter-ocagent/package.json
+++ b/packages/opencensus-web-exporter-ocagent/package.json
@@ -43,6 +43,7 @@
     "access": "public"
   },
   "devDependencies": {
+    "@opencensus/core": "^0.0.8",
     "@types/jasmine": "^3.3.4",
     "@types/node": "^10.12.18",
     "gts": "^0.9.0",
@@ -58,8 +59,9 @@
     "ts-loader": "^5.1.0",
     "typescript": "^3.1.6",
     "webpack": "^4.18.0",
-    "webpack-cli": "^3.1.0",
-    "@opencensus/core": "0.0.8"
+    "webpack-cli": "^3.1.0"
   },
-  "dependencies": {}
+  "dependencies": {
+    "@opencensus/web-core": "^0.0.1"
+  }
 }

--- a/packages/opencensus-web-exporter-ocagent/src/adapters.ts
+++ b/packages/opencensus-web-exporter-ocagent/src/adapters.ts
@@ -66,9 +66,7 @@ function adaptSpanKind(coreKind: string): apiTypes.SpanKind {
     case 'CLIENT': {
       return apiTypes.SpanKind.CLIENT;
     }
-    default: {
-      return apiTypes.SpanKind.UNSPECIFIED;
-    }
+    default: { return apiTypes.SpanKind.UNSPECIFIED; }
   }
 }
 
@@ -110,9 +108,7 @@ function adaptMessageEventType(type: string): apiTypes.MessageEventType {
     case 'RECEIVED': {
       return apiTypes.MessageEventType.RECEIVED;
     }
-    default: {
-      return apiTypes.MessageEventType.UNSPECIFIED;
-    }
+    default: { return apiTypes.MessageEventType.UNSPECIFIED; }
   }
 }
 
@@ -145,9 +141,7 @@ function adaptLinkType(type: string): apiTypes.LinkType {
     case 'PARENT_LINKED_SPAN': {
       return apiTypes.LinkType.PARENT_LINKED_SPAN;
     }
-    default: {
-      return apiTypes.LinkType.UNSPECIFIED;
-    }
+    default: { return apiTypes.LinkType.UNSPECIFIED; }
   }
 }
 

--- a/packages/opencensus-web-exporter-ocagent/src/adapters.ts
+++ b/packages/opencensus-web-exporter-ocagent/src/adapters.ts
@@ -15,13 +15,15 @@
  */
 
 import * as coreTypes from '@opencensus/core';
+import * as webCore from '@opencensus/web-core';
 import * as apiTypes from './api-types';
 
 /**
  * Converts a RootSpan type from @opencensus/core to the Span JSON structure
  * expected by the OpenCensus Agent's HTTP/JSON (grpc-gateway) API.
  */
-export function adaptRootSpan(rootSpan: coreTypes.RootSpan): apiTypes.Span[] {
+export function adaptRootSpan(rootSpan: coreTypes.RootSpan|
+                              webCore.RootSpan): apiTypes.Span[] {
   const adaptedSpans: apiTypes.Span[] = rootSpan.spans.map(adaptSpan);
   adaptedSpans.unshift(adaptSpan(rootSpan));
   return adaptedSpans;
@@ -64,7 +66,9 @@ function adaptSpanKind(coreKind: string): apiTypes.SpanKind {
     case 'CLIENT': {
       return apiTypes.SpanKind.CLIENT;
     }
-    default: { return apiTypes.SpanKind.UNSPECIFIED; }
+    default: {
+      return apiTypes.SpanKind.UNSPECIFIED;
+    }
   }
 }
 
@@ -106,7 +110,9 @@ function adaptMessageEventType(type: string): apiTypes.MessageEventType {
     case 'RECEIVED': {
       return apiTypes.MessageEventType.RECEIVED;
     }
-    default: { return apiTypes.MessageEventType.UNSPECIFIED; }
+    default: {
+      return apiTypes.MessageEventType.UNSPECIFIED;
+    }
   }
 }
 
@@ -139,7 +145,9 @@ function adaptLinkType(type: string): apiTypes.LinkType {
     case 'PARENT_LINKED_SPAN': {
       return apiTypes.LinkType.PARENT_LINKED_SPAN;
     }
-    default: { return apiTypes.LinkType.UNSPECIFIED; }
+    default: {
+      return apiTypes.LinkType.UNSPECIFIED;
+    }
   }
 }
 
@@ -156,7 +164,25 @@ function adaptLinks(links: coreTypes.Link[]): apiTypes.Links {
   return {link: links.map(adaptLink)};
 }
 
-function adaptSpan(span: coreTypes.Span): apiTypes.Span {
+/**
+ * Returns an ISO date string for a span high-resolution browser performance
+ * clock time when available (if the span was a `webCore.Span` instance) or
+ * otherwise using the more general `@opencensus/core` Date-typed times.
+ */
+function adaptSpanTime(perfTime: number|undefined, fallbackTime: Date) {
+  return perfTime === undefined ? fallbackTime.toISOString() :
+                                  webCore.getIsoDateStrForPerfTime(perfTime);
+}
+
+/** Interface to represent that a coreTypes.Span may be a webCore.Span */
+interface MaybeWebSpan {
+  startPerfTime?: number;
+  endPerfTime?: number;
+  startTime: Date;
+  endTime: Date;
+}
+
+function adaptSpan(span: coreTypes.Span|webCore.Span): apiTypes.Span {
   // The stackTrace and childSpanCount attributes are not currently supported by
   // opencensus-web.
   return {
@@ -166,8 +192,9 @@ function adaptSpan(span: coreTypes.Span): apiTypes.Span {
     parentSpanId: hexToBase64(span.parentSpanId),
     name: adaptString(span.name),
     kind: adaptSpanKind(span.kind),
-    startTime: span.startTime.toISOString(),
-    endTime: span.endTime.toISOString(),
+    startTime:
+        adaptSpanTime((span as MaybeWebSpan).startPerfTime, span.startTime),
+    endTime: adaptSpanTime((span as MaybeWebSpan).endPerfTime, span.endTime),
     attributes: adaptAttributes(span.attributes),
     timeEvents: adaptTimeEvents(span.annotations, span.messageEvents),
     links: adaptLinks(span.links),


### PR DESCRIPTION
This makes the `@opencensus/web-exporter-ocagent` look for the web-specific `startPerfTime` and `endPerfTime` fields and when those are present, it will export using a nanosecond-precision timestamp.

If those are not there (they aren't part of the general `@opencensus/core` span type), it falls back to using the Date-typed `startTime` and `endTime` fields.