### PR TITLE
Add url parsing utility

### DIFF
--- a/packages/opencensus-web-core/src/common/url-util.ts
+++ b/packages/opencensus-web-core/src/common/url-util.ts
@@ -1,7 +1,7 @@
 /**
  * Copyright 2019, OpenCensus Authors
  *
- * Licensed under the Apache License, Version 2.0 the "License";
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *

--- a/packages/opencensus-web-core/src/common/url-util.ts
+++ b/packages/opencensus-web-core/src/common/url-util.ts
@@ -1,0 +1,46 @@
+/**
+ * Copyright 2019, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Interface to represent the components of a parsed URL.
+ * The field comments below reference this sample URL:
+ *    https://example.com:3000/pathname/?search=test#hash
+ */
+export interface ParsedUrl {
+  /** Protocol of the URL. E.g. https */
+  protocol: string;
+  /** Host name only (no port). E.g. example.com */
+  hostname: string;
+  /** Port number if explicitly specified (else empty string). E.g. 3000 */
+  port: string;
+  /** Host portion of the URL including port. E.g. example.com:3000 */
+  host: string;
+  /** Origin with protocol, hostname and port. E.g. https://example.com:3000 */
+  origin: string;
+  /** Request URL path. E.g. /pathname/ */
+  pathname: string;
+  /** Portion of the URL after and including the `#` character. E.g. #hash */
+  hash: string;
+  /** Query string before the `#` char including the `?`. E.g. ?search=test */
+  search: string;
+}
+
+/** Parses the given URL into components. */
+export function parseUrl(url: string): ParsedUrl {
+  const aTag = document.createElement('a');
+  aTag.href = url;
+  return aTag;
+}

--- a/packages/opencensus-web-core/src/common/url-util.ts
+++ b/packages/opencensus-web-core/src/common/url-util.ts
@@ -20,22 +20,26 @@
  *    https://example.com:3000/pathname/?search=test#hash
  */
 export interface ParsedUrl {
-  /** Protocol of the URL. E.g. https */
-  protocol: string;
+  /** Protocol of the URL including the colon. E.g. https: */
+  readonly protocol: string;
   /** Host name only (no port). E.g. example.com */
-  hostname: string;
-  /** Port number if explicitly specified (else empty string). E.g. 3000 */
-  port: string;
+  readonly hostname: string;
+  /**
+   * Port number if explicitly specified (else empty string). E.g. 3000
+   * This is a string type to match the type of the field in the document <a>
+   * tag that is used to implement this.
+   */
+  readonly port: string;
   /** Host portion of the URL including port. E.g. example.com:3000 */
-  host: string;
+  readonly host: string;
   /** Origin with protocol, hostname and port. E.g. https://example.com:3000 */
-  origin: string;
+  readonly origin: string;
   /** Request URL path. E.g. /pathname/ */
-  pathname: string;
+  readonly pathname: string;
   /** Portion of the URL after and including the `#` character. E.g. #hash */
-  hash: string;
+  readonly hash: string;
   /** Query string before the `#` char including the `?`. E.g. ?search=test */
-  search: string;
+  readonly search: string;
 }
 
 /** Parses the given URL into components. */

--- a/packages/opencensus-web-core/test/index.ts
+++ b/packages/opencensus-web-core/test/index.ts
@@ -23,3 +23,4 @@ import './test-span';
 import './test-time-util';
 import './test-tracer';
 import './test-tracing';
+import './test-url-util';

--- a/packages/opencensus-web-core/test/test-url-util.ts
+++ b/packages/opencensus-web-core/test/test-url-util.ts
@@ -1,0 +1,34 @@
+/**
+ * Copyright 2019, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import 'jasmine';
+import {parseUrl} from '../src/common/url-util';
+
+describe('parseUrl', () => {
+  it('parses a URL into its various components', () => {
+    const parsedUrl =
+        parseUrl('https://example.com:3000/pathname/?search=test#hash');
+
+    expect(parsedUrl.protocol).toBe('https');
+    expect(parsedUrl.hostname).toBe('example.com');
+    expect(parsedUrl.port).toBe('3000');
+    expect(parsedUrl.host).toBe('example.com:3000');
+    expect(parsedUrl.origin).toBe('http://example.com:3000');
+    expect(parsedUrl.pathname).toBe('/pathname/');
+    expect(parsedUrl.hash).toBe('#hash');
+    expect(parsedUrl.search).toBe('?search=test');
+  });
+});

--- a/packages/opencensus-web-core/test/test-url-util.ts
+++ b/packages/opencensus-web-core/test/test-url-util.ts
@@ -26,7 +26,7 @@ describe('parseUrl', () => {
     expect(parsedUrl.hostname).toBe('example.com');
     expect(parsedUrl.port).toBe('3000');
     expect(parsedUrl.host).toBe('example.com:3000');
-    expect(parsedUrl.origin).toBe('http://example.com:3000');
+    expect(parsedUrl.origin).toBe('https://example.com:3000');
     expect(parsedUrl.pathname).toBe('/pathname/');
     expect(parsedUrl.hash).toBe('#hash');
     expect(parsedUrl.search).toBe('?search=test');

--- a/packages/opencensus-web-core/test/test-url-util.ts
+++ b/packages/opencensus-web-core/test/test-url-util.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import 'jasmine';
 import {parseUrl} from '../src/common/url-util';
 
 describe('parseUrl', () => {
@@ -22,7 +21,7 @@ describe('parseUrl', () => {
     const parsedUrl =
         parseUrl('https://example.com:3000/pathname/?search=test#hash');
 
-    expect(parsedUrl.protocol).toBe('https');
+    expect(parsedUrl.protocol).toBe('https:');
     expect(parsedUrl.hostname).toBe('example.com');
     expect(parsedUrl.port).toBe('3000');
     expect(parsedUrl.host).toBe('example.com:3000');
@@ -30,5 +29,19 @@ describe('parseUrl', () => {
     expect(parsedUrl.pathname).toBe('/pathname/');
     expect(parsedUrl.hash).toBe('#hash');
     expect(parsedUrl.search).toBe('?search=test');
+  });
+
+  it('correctly parases a url without a port', () => {
+    const parsedUrl =
+        parseUrl('http://example.com/path1/path2?search=test&format=json');
+
+    expect(parsedUrl.protocol).toBe('http:');
+    expect(parsedUrl.hostname).toBe('example.com');
+    expect(parsedUrl.port).toBe('');
+    expect(parsedUrl.host).toBe('example.com');
+    expect(parsedUrl.origin).toBe('http://example.com');
+    expect(parsedUrl.pathname).toBe('/path1/path2');
+    expect(parsedUrl.hash).toBe('');
+    expect(parsedUrl.search).toBe('?search=test&format=json');
   });
 });


### PR DESCRIPTION
This will be used by the upcoming browser timing instrumentation package to specify the various HTTP attributes from the [OpenCensus HTTP specs](https://github.com/census-instrumentation/opencensus-specs/blob/master/trace/HTTP.md#attributes) such as host and path.