### PR TITLE
Export browser performance timestamps for time events

### DIFF
--- a/packages/opencensus-web-core/src/index.ts
+++ b/packages/opencensus-web-core/src/index.ts
@@ -20,8 +20,15 @@ export {Span} from './trace/model/span';
 export {Tracer} from './trace/model/tracer';
 export {Tracing} from './trace/model/tracing';
 export * from './trace/model/types';
+export * from './trace/model/attribute-keys';
 
 // Re-export types this uses from @opencensus/core.
-export {Annotation, Attributes, Link, MessageEvent, SpanContext, SpanEventListener, TraceState, Propagation, Exporter, TracerConfig, Config} from '@opencensus/core';
+export {Annotation, Attributes, Link, SpanContext, SpanEventListener, TraceState, Propagation, Exporter, TracerConfig, Config} from '@opencensus/core';
 
 export * from './common/time-util';
+export * from './common/url-util';
+
+// Export global tracing instance.
+import {Tracing} from './trace/model/tracing';
+const tracing = new Tracing();
+export {tracing};

--- a/packages/opencensus-web-core/src/trace/model/root-span.ts
+++ b/packages/opencensus-web-core/src/trace/model/root-span.ts
@@ -15,16 +15,14 @@
  */
 
 import * as coreTypes from '@opencensus/core';
-
 import {randomTraceId} from '../../internal/util';
-
 import {Span} from './span';
 import {SpanKind} from './types';
 
 /** Simple mock root span for use in use tests. */
 export class RootSpan extends Span implements coreTypes.RootSpan {
   /** A list of child spans. */
-  spans: coreTypes.Span[] = [];
+  spans: Span[] = [];
 
   constructor(
       /** Trace associated with this root span. */
@@ -54,6 +52,7 @@ export class RootSpan extends Span implements coreTypes.RootSpan {
     child.traceState = this.traceState;
     if (name) child.name = name;
     if (kind) child.kind = kind;
+    child.start();
     this.spans.push(child);
     return child;
   }

--- a/packages/opencensus-web-core/src/trace/model/span.ts
+++ b/packages/opencensus-web-core/src/trace/model/span.ts
@@ -15,10 +15,12 @@
  */
 
 import * as coreTypes from '@opencensus/core';
+
 import {LOGGER} from '../../common/console-logger';
 import {getDateForPerfTime} from '../../common/time-util';
 import {randomSpanId} from '../../internal/util';
-import {SpanKind} from './types';
+
+import {MessageEvent, SpanKind} from './types';
 
 /** Default span name if none is specified. */
 const DEFAULT_SPAN_NAME = 'unnamed';
@@ -66,7 +68,7 @@ export class Span implements coreTypes.Span {
   annotations: coreTypes.Annotation[] = [];
 
   /** Event describing messages sent/received between Spans. */
-  messageEvents: coreTypes.MessageEvent[] = [];
+  messageEvents: MessageEvent[] = [];
 
   /** Pointers from the current span to another span */
   links: coreTypes.Link[] = [];

--- a/packages/opencensus-web-core/src/trace/model/types.ts
+++ b/packages/opencensus-web-core/src/trace/model/types.ts
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+// TODO(draffensperger): Remove these once the new @opencensus/core version is
+// pushed that has these enums/fields natively.
+
 /**
  * Type of span. Can be used to specify additional relationships between spans
  * in addition to a parent/child relationship.
@@ -57,4 +60,23 @@ export enum MessageEventType {
   SENT = 'SENT',
   /** Indicates a received message. */
   RECEIVED = 'RECEIVED',
+}
+
+/**
+ * An event describing a message sent/received between Spans.
+ */
+export interface MessageEvent {
+  /** A timestamp for the event. */
+  timestamp: number;
+  /** Indicates whether the message was sent or received. */
+  type: string;
+  /** An identifier for the MessageEvent's message. */
+  id: string;
+  /** The number of uncompressed bytes sent or received. */
+  uncompressedSize?: number;
+  /**
+   * The number of compressed bytes sent or received. If zero or
+   * undefined, assumed to be the same size as uncompressed.
+   */
+  compressedSize?: number;
 }

--- a/packages/opencensus-web-exporter-ocagent/src/adapters.ts
+++ b/packages/opencensus-web-exporter-ocagent/src/adapters.ts
@@ -134,15 +134,24 @@ function adaptMessageEventType(type: string): apiTypes.MessageEventType {
 
 function adaptMessageEvent(messageEvent: coreTypes.MessageEvent):
     apiTypes.TimeEvent {
+  const apiMessageEvent: apiTypes.MessageEvent = {
+    // tslint:disable-next-line:ban Needed to parse hexadecimal.
+    id: String(parseInt(messageEvent.id, 16)),
+    type: adaptMessageEventType(messageEvent.type),
+  };
+  // TODO(draffensperger): Remove this extra logic once there is a new
+  // @opencensus/core release with message event size types
+  if ((messageEvent as webCore.MessageEvent).uncompressedSize) {
+    apiMessageEvent.uncompressedSize =
+        (messageEvent as webCore.MessageEvent).uncompressedSize;
+  }
+  if ((messageEvent as webCore.MessageEvent).compressedSize) {
+    apiMessageEvent.compressedSize =
+        (messageEvent as webCore.MessageEvent).compressedSize;
+  }
   return {
     time: adaptTimestampNumber(messageEvent.timestamp),
-    messageEvent: {
-      // tslint:disable-next-line:ban Needed to parse hexadecimal.
-      id: String(parseInt(messageEvent.id, 16)),
-      type: adaptMessageEventType(messageEvent.type),
-      uncompressedSize: messageEvent.uncompressedSize,
-      compressedSize: messageEvent.compressedSize,
-    },
+    messageEvent: apiMessageEvent,
   };
 }
 

--- a/packages/opencensus-web-exporter-ocagent/src/adapters.ts
+++ b/packages/opencensus-web-exporter-ocagent/src/adapters.ts
@@ -19,11 +19,17 @@ import * as webCore from '@opencensus/web-core';
 import * as apiTypes from './api-types';
 
 /**
+ * This is a recent time in epoch milliseconds. Timestamps before this are
+ * assumed to be in browser performance clock millseconds, and timestamps after
+ * it are assumed to be in epoch milliseconds.
+ */
+const RECENT_EPOCH_MS = 1500000000000;  // July 13, 2017.
+
+/**
  * Converts a RootSpan type from @opencensus/core to the Span JSON structure
  * expected by the OpenCensus Agent's HTTP/JSON (grpc-gateway) API.
  */
-export function adaptRootSpan(rootSpan: coreTypes.RootSpan|
-                              webCore.RootSpan): apiTypes.Span[] {
+export function adaptRootSpan(rootSpan: coreTypes.RootSpan): apiTypes.Span[] {
   const adaptedSpans: apiTypes.Span[] = rootSpan.spans.map(adaptSpan);
   adaptedSpans.unshift(adaptSpan(rootSpan));
   return adaptedSpans;
@@ -92,12 +98,26 @@ function adaptAttributes(attributes: coreTypes.Attributes):
 
 function adaptAnnotation(annotation: coreTypes.Annotation): apiTypes.TimeEvent {
   return {
-    time: new Date(annotation.timestamp).toISOString(),
+    time: adaptTimestampNumber(annotation.timestamp),
     annotation: {
       description: adaptString(annotation.description),
       attributes: adaptAttributes(annotation.attributes),
     },
   };
+}
+
+/**
+ * Adapts a timestamp number for an annotation or message event. For
+ * opencensus-web, those timestamps are allowed to be either in epoch
+ * milliseconds or in browser performance clock milliseconds. This determines
+ * which one it likely is based on the size of the number.
+ * @return ISO string for timestamp
+ */
+function adaptTimestampNumber(timestamp: number): string {
+  if (timestamp > RECENT_EPOCH_MS) {
+    return new Date(timestamp).toISOString();
+  }
+  return webCore.getIsoDateStrForPerfTime(timestamp);
 }
 
 function adaptMessageEventType(type: string): apiTypes.MessageEventType {
@@ -115,11 +135,13 @@ function adaptMessageEventType(type: string): apiTypes.MessageEventType {
 function adaptMessageEvent(messageEvent: coreTypes.MessageEvent):
     apiTypes.TimeEvent {
   return {
-    time: new Date(messageEvent.timestamp).toISOString(),
+    time: adaptTimestampNumber(messageEvent.timestamp),
     messageEvent: {
       // tslint:disable-next-line:ban Needed to parse hexadecimal.
       id: String(parseInt(messageEvent.id, 16)),
       type: adaptMessageEventType(messageEvent.type),
+      uncompressedSize: messageEvent.uncompressedSize,
+      compressedSize: messageEvent.compressedSize,
     },
   };
 }
@@ -176,7 +198,7 @@ interface MaybeWebSpan {
   endTime: Date;
 }
 
-function adaptSpan(span: coreTypes.Span|webCore.Span): apiTypes.Span {
+function adaptSpan(span: coreTypes.Span): apiTypes.Span {
   // The stackTrace and childSpanCount attributes are not currently supported by
   // opencensus-web.
   return {

--- a/packages/opencensus-web-exporter-ocagent/src/api-types.ts
+++ b/packages/opencensus-web-exporter-ocagent/src/api-types.ts
@@ -420,12 +420,12 @@ export interface MessageEvent {
   /**
    * The number of uncompressed bytes sent or received.
    */
-  uncompressedSize?: string;
+  uncompressedSize?: string|number;
   /**
    * The number of compressed bytes sent or received. If zero, assumed to be the
    * same size as uncompressed.
    */
-  compressedSize?: string;
+  compressedSize?: string|number;
 }
 
 /**

--- a/packages/opencensus-web-exporter-ocagent/test/test-adapters.ts
+++ b/packages/opencensus-web-exporter-ocagent/test/test-adapters.ts
@@ -175,12 +175,26 @@ describe('Core to API Span adapters', () => {
     webSpan1.traceId = '00000000000000000000000000000001';
     webSpan1.startPerfTime = 10.1;
     webSpan1.endPerfTime = 20.113;
+    webSpan1.messageEvents = [{
+      id: '1',
+      timestamp: 19.002,
+      type: webTypes.MessageEventType.SENT,
+      uncompressedSize: 22,
+      compressedSize: 15,
+      // TODO(draffensperger): remove the `as coreTypes.MessageEvent` once core
+      // interface has new fields.
+    } as coreTypes.MessageEvent];
     const webRootSpan = new webTypes.RootSpan(tracer);
     webRootSpan.spans = [webSpan1];
     webRootSpan.startPerfTime = 5.001;
     webRootSpan.endPerfTime = 30.000001;
     webRootSpan.id = '000000000000000b';
     webRootSpan.traceId = '00000000000000000000000000000001';
+    webRootSpan.annotations = [{
+      timestamp: 41.001,
+      description: 'annotation with perf time',
+      attributes: {attr1: true},
+    }];
 
     const apiSpans = adaptRootSpan(webRootSpan);
 
@@ -195,7 +209,25 @@ describe('Core to API Span adapters', () => {
         startTime: '2019-01-20T16:00:00.005001000Z',
         endTime: '2019-01-20T16:00:00.030000001Z',
         attributes: {attributeMap: {}},
-        timeEvents: {timeEvent: []},
+        timeEvents: {
+          timeEvent: [
+            {
+              time: '2019-01-20T16:00:00.041001000Z',
+              annotation: {
+                description: {
+                  value: 'annotation with perf time',
+                },
+                attributes: {
+                  attributeMap: {
+                    attr1: {
+                      boolValue: true,
+                    },
+                  },
+                },
+              },
+            },
+          ],
+        },
         links: {link: []},
         status: {},
         sameProcessAsParentSpan: true,
@@ -210,7 +242,17 @@ describe('Core to API Span adapters', () => {
         startTime: '2019-01-20T16:00:00.010100000Z',
         endTime: '2019-01-20T16:00:00.020113000Z',
         attributes: {attributeMap: {}},
-        timeEvents: {timeEvent: []},
+        timeEvents: {
+          timeEvent: [{
+            time: '2019-01-20T16:00:00.019002000Z',
+            messageEvent: {
+              id: '1',
+              type: apiTypes.MessageEventType.SENT,
+              uncompressedSize: 22,
+              compressedSize: 15,
+            },
+          }],
+        },
         links: {link: []},
         status: {},
         sameProcessAsParentSpan: true,


### PR DESCRIPTION
This makes the OpenCensus web agent exporter support browser performance times in the message event and annotation `timestamp` field. The field is a number and for OpenCensus Node represents an epoch time.

However, JS doubles in epoch time have less accuracy than small JS numbers, and it's more convenient for the instrumentation to be able to set performance times as the `timestamp` field since that's what the browser performance API and `performance.now()` return.

This handles both cases by checking the value of the numberic field to determine whether it's an epoch time or performance time - maybe a little hacky but it works and is compatible with both uses.