### PR TITLE
Add function to adjust performance origin based on server time

### DIFF
--- a/packages/opencensus-web-core/src/common/time-util.ts
+++ b/packages/opencensus-web-core/src/common/time-util.ts
@@ -14,10 +14,62 @@
  * limitations under the License.
  */
 
+/** Polyfill value of `performance.timeOrigin` for browser that lack support. */
 let perfOriginPolyfill = 0;
+/** If non-zero, the approximate peformance clock origin in server time. */
+let perfOriginInServerTime = 0;
 
-/** Returns the origin of the browser performance clock in epoch millis. */
+/**
+ * Returns the origin of the browser performance clock in epoch millis.
+ * This can be adjusted to align more closely with the server's clock using the
+ * `adjustPerfTimeOrigin` function.
+ */
 export function getPerfTimeOrigin(): number {
+  return perfOriginInServerTime ? perfOriginInServerTime :
+                                  getClientPerfTimeOrigin();
+}
+
+/**
+ * Adjusts the performance clock time origin based on server clock times for the
+ * start and duration of the navigation fetch (the initial HTML load request).
+ *
+ * This adjusts the client clock such that the network time is evenly spread on
+ * both sides of the request, so that the server's span will be positioned right
+ * in the middle of the client's span. This enables visualizing the server and
+ * client spans no the same timeline even if they have clock skew.
+ *
+ * @param serverNavFetchStartTime The server's measurement of the request start
+ *     in epoch milliseconds from the server clock. This would be sent back to
+ *     the client in a <script> in the rendered HTML.
+ * @param serverNavFetchDuration The server's measurement of the request
+ *     duration in milliseconds. This would also be sent to the client.
+ */
+export function adjustPerfTimeOrigin(
+    serverNavFetchStartTime: number, serverNavFetchDuration: number) {
+  // If there is no performance timing info, we don't have the client's
+  // start/end times for the navigation fetch, so we can't accurately use the
+  // server times to adjust the client time origin.
+  if (!performance.timing) return;
+  const clientStart = performance.timing.requestStart;
+  const clientEnd = performance.timing.responseStart;
+  const clientNavFetchDuration = clientEnd - clientStart;
+
+  // Server time is more than client time, which we don't expect, so don't try
+  // to adjust the time origin.
+  if (serverNavFetchDuration > clientNavFetchDuration) return;
+
+  const networkTime = clientNavFetchDuration - serverNavFetchDuration;
+  const halfNetworkTime = networkTime / 2;
+  const clientStartInServerTime = serverNavFetchStartTime - halfNetworkTime;
+  perfOriginInServerTime = clientStartInServerTime - clientStart;
+}
+
+/** Helper function used for testing. */
+function clearAdjustedPerfTime() {
+  perfOriginInServerTime = 0;
+}
+
+function getClientPerfTimeOrigin() {
   if (performance.timeOrigin) return performance.timeOrigin;
   if (!perfOriginPolyfill) {
     perfOriginPolyfill = Date.now() - performance.now();
@@ -59,3 +111,5 @@ function wholeAndFraction(num: number): [number, number] {
   const fraction = num - whole;
   return [whole, fraction];
 }
+
+export const TEST_ONLY = {clearAdjustedPerfTime};


### PR DESCRIPTION
This will enable visualizing server and client spans on the same trace timeline even if there is some amount of clock skew between the server and the browser client.

For cases where the server and client have the same trace ID, the time adjustments could be done in the OpenCensus collector.

However, for security purposes, we will want to allow people to set up linked traces between client and server, which means that different sharded collectors could proccess the client/server spans. Then if a trace viewer were to pull in spans from both linked traces and try to visualize them, it would be difficult if there is clock skew.

This approach provides a simple mechanism for users to send server request start and duration times for the initial load to the client so that it can do at least a basic clock sync before writing its spans.

cc/ @bogdandrutu 