### PR TITLE
Switch to CircleCi `machine` build type

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,33 +11,8 @@ release_tags: &release_tags
 version: 2.0
 jobs:
   build:
-    docker:
-      # specify the version you desire here
-      - image: circleci/node:10-browsers
-
-      # Specify service dependencies here if necessary
-      # CircleCI maintains a library of pre-built images
-      # documented at https://circleci.com/docs/2.0/circleci-images/
-      # - image: circleci/mongo:3.4.4
-
-    working_directory: ~/repo
-
+    machine: true
     steps:
       - checkout
-
-      # Download and cache dependencies
-      - restore_cache:
-          keys:
-          - v1-dependencies-{{ checksum "package.json" }}
-          # fallback to using the latest cache if no exact match is found
-          - v1-dependencies-
-
       - run: npm install
-
-      - save_cache:
-          paths:
-            - node_modules
-          key: v1-dependencies-{{ checksum "package.json" }}
-
-      # run tests!
       - run: npm test

--- a/packages/opencensus-web-core/package-lock.json
+++ b/packages/opencensus-web-core/package-lock.json
@@ -4037,6 +4037,7 @@
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
       "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
       "dev": true,
+      "optional": true,
       "requires": {
         "safe-buffer": "^5.1.2",
         "yallist": "^3.0.0"
@@ -4046,7 +4047,8 @@
           "version": "3.0.3",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
           "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/packages/opencensus-web-core/test/test-span.ts
+++ b/packages/opencensus-web-core/test/test-span.ts
@@ -16,6 +16,7 @@
 
 import {LinkType, MessageEventType} from '../src/trace/model/enums';
 import {Span} from '../src/trace/model/span';
+import {mockGetterOrValue, restoreGetterOrValue} from './util';
 
 describe('Span', () => {
   let span: Span;
@@ -33,17 +34,27 @@ describe('Span', () => {
     expect(span.id).toBe('000000000000000b');
   });
 
-  it('calculates time fields based on startPerfTime/endPerfTime', () => {
-    expect(span.ended).toBe(false);
+  describe('time fields', () => {
+    let realTimeOrigin: number;
+    beforeEach(() => {
+      realTimeOrigin = performance.timeOrigin;
+    });
+    afterEach(() => {
+      restoreGetterOrValue(performance, 'timeOrigin', realTimeOrigin);
+    });
 
-    spyOnProperty(performance, 'timeOrigin').and.returnValue(1548000000000);
-    span.startPerfTime = 2;
-    span.endPerfTime = 4.5;
+    it('calculates them based on startPerfTime/endPerfTime', () => {
+      expect(span.ended).toBe(false);
 
-    expect(span.ended).toBe(true);
-    expect(span.startTime.getTime()).toBe(1548000000002);
-    expect(span.endTime.getTime()).toBe(1548000000004);
-    expect(span.duration).toBe(2.5);
+      mockGetterOrValue(performance, 'timeOrigin', 1548000000000);
+      span.startPerfTime = 2;
+      span.endPerfTime = 4.5;
+
+      expect(span.ended).toBe(true);
+      expect(span.startTime.getTime()).toBe(1548000000002);
+      expect(span.endTime.getTime()).toBe(1548000000004);
+      expect(span.duration).toBe(2.5);
+    });
   });
 
   it('calculates isRootSpan based on parentSpanId', () => {

--- a/packages/opencensus-web-core/test/test-time-util.ts
+++ b/packages/opencensus-web-core/test/test-time-util.ts
@@ -15,99 +15,104 @@
  */
 
 import {adjustPerfTimeOrigin, getDateForPerfTime, getIsoDateStrForPerfTime, getPerfTimeOrigin, TEST_ONLY} from '../src/common/time-util';
+import {mockGetterOrValue, restoreGetterOrValue} from './util';
 
-describe('getPerfTimeOrigin', () => {
-  it('returns `performance.timeOrigin` if set', () => {
-    spyOnProperty(performance, 'timeOrigin').and.returnValue(1548000000000);
-
-    expect(getPerfTimeOrigin()).toBe(1548000000000);
-  });
-
-  it('calculates via polyfill if `performance.timeOrigin` unset', () => {
-    spyOnProperty(performance, 'timeOrigin').and.returnValue(undefined);
-    spyOn(Date, 'now').and.returnValue(1548000009999);
-    spyOn(performance, 'now').and.returnValue(9999);
-
-    expect(getPerfTimeOrigin()).toBe(1548000000000);
-  });
-});
-
-describe('adjustPerfTimeOrigin', () => {
-  const CLIENT_TIME_ORIGIN = 1548000000000;
+describe('time utils', () => {
+  let realTimeOrigin: number;
   beforeEach(() => {
-    spyOnProperty(performance, 'timeOrigin')
-        .and.returnValue(CLIENT_TIME_ORIGIN);
+    realTimeOrigin = performance.timeOrigin;
   });
   afterEach(() => {
-    TEST_ONLY.clearAdjustedPerfTime();
+    restoreGetterOrValue(performance, 'timeOrigin', realTimeOrigin);
   });
 
-  it('keeps client time origin if no performance timing missing', () => {
-    spyOnProperty(performance, 'timing').and.returnValue(undefined);
-    adjustPerfTimeOrigin(1548000001000.2, 5.1);
-    expect(getPerfTimeOrigin()).toBe(CLIENT_TIME_ORIGIN);
+  describe('getPerfTimeOrigin', () => {
+    it('returns `performance.timeOrigin` if set', () => {
+      mockGetterOrValue(performance, 'timeOrigin', 1548000000000);
+      expect(getPerfTimeOrigin()).toBe(1548000000000);
+    });
+
+    it('calculates via polyfill if `performance.timeOrigin` unset', () => {
+      mockGetterOrValue(performance, 'timeOrigin', undefined);
+      spyOn(Date, 'now').and.returnValue(1548000009999);
+      spyOn(performance, 'now').and.returnValue(9999);
+    });
   });
 
-  it('keeps client time origin if server time longer than client', () => {
-    // Client nav fetch duration is 5ms
-    spyOnProperty(performance.timing, 'requestStart').and.returnValue(10.1);
-    spyOnProperty(performance.timing, 'responseStart').and.returnValue(15.1);
+  describe('adjustPerfTimeOrigin', () => {
+    const CLIENT_TIME_ORIGIN = 1548000000000;
+    beforeEach(() => {
+      mockGetterOrValue(performance, 'timeOrigin', CLIENT_TIME_ORIGIN);
+    });
+    afterEach(() => {
+      TEST_ONLY.clearAdjustedPerfTime();
+    });
 
-    // Server nav fetch duration is 10ms
-    adjustPerfTimeOrigin(1548000001000.2, /* serverNavFetchDuration */ 10);
+    it('keeps client time origin if performance timing missing', () => {
+      spyOnProperty(performance, 'timing').and.returnValue(undefined);
+      adjustPerfTimeOrigin(1548000001000.2, 5.1);
+      expect(getPerfTimeOrigin()).toBe(CLIENT_TIME_ORIGIN);
+    });
 
-    expect(getPerfTimeOrigin()).toBe(CLIENT_TIME_ORIGIN);
+    it('keeps client time origin if server time longer than client', () => {
+      // Client nav fetch duration is 5ms
+      spyOnProperty(performance.timing, 'requestStart').and.returnValue(10.1);
+      spyOnProperty(performance.timing, 'responseStart').and.returnValue(15.1);
+
+      // Server nav fetch duration is 10ms
+      adjustPerfTimeOrigin(1548000001000.2, /* serverNavFetchDuration */ 10);
+
+      expect(getPerfTimeOrigin()).toBe(CLIENT_TIME_ORIGIN);
+    });
+
+    it('adjusts origin to center server span in client span', () => {
+      const clientNavFetchStartInPerfTime = 10;  // Performance clock millis.
+      spyOnProperty(performance.timing, 'requestStart')
+          .and.returnValue(clientNavFetchStartInPerfTime);
+      const clientNavFetchEndInPerfTime = 18;  // Performance clock millis.
+      spyOnProperty(performance.timing, 'responseStart')
+          .and.returnValue(clientNavFetchEndInPerfTime);
+
+      const serverNavFetchStartEpochMillis = 1500000001000;  // Epoch millis.
+      const serverNavFetchDuration = 6;                      // Duration millis
+      adjustPerfTimeOrigin(
+          serverNavFetchStartEpochMillis, serverNavFetchDuration);
+
+      // Calculations to make the expectation clearer:
+      const clientNavFetchDuration =
+          clientNavFetchEndInPerfTime - clientNavFetchStartInPerfTime;
+      expect(clientNavFetchDuration).toBe(8);  // Duration millis
+      const networkTime = clientNavFetchDuration - serverNavFetchDuration;
+      expect(networkTime).toBe(2);  // Duration millis
+      const clientNavStartInEpochMillis =
+          serverNavFetchStartEpochMillis - networkTime / 2;
+      expect(clientNavStartInEpochMillis).toBe(1500000000999);
+      const perfOriginInEpochMillis =
+          clientNavStartInEpochMillis - clientNavFetchStartInPerfTime;
+      expect(perfOriginInEpochMillis).toBe(1500000000989);
+
+      expect(getPerfTimeOrigin()).toBe(perfOriginInEpochMillis);
+    });
   });
 
-  it('adjusts origin to center server span in client span', () => {
-    const clientNavFetchStartInPerfTime = 10;  // Performance clock millis.
-    spyOnProperty(performance.timing, 'requestStart')
-        .and.returnValue(clientNavFetchStartInPerfTime);
-    const clientNavFetchEndInPerfTime = 18;  // Performance clock millis.
-    spyOnProperty(performance.timing, 'responseStart')
-        .and.returnValue(clientNavFetchEndInPerfTime);
-
-    const serverNavFetchStartEpochMillis = 1500000001000;  // Epoch millis.
-    const serverNavFetchDuration = 6;                      // Duration millis
-    adjustPerfTimeOrigin(
-        serverNavFetchStartEpochMillis, serverNavFetchDuration);
-
-    // Calculations to make the expectation clearer:
-    const clientNavFetchDuration =
-        clientNavFetchEndInPerfTime - clientNavFetchStartInPerfTime;
-    expect(clientNavFetchDuration).toBe(8);  // Duration millis
-    const networkTime = clientNavFetchDuration - serverNavFetchDuration;
-    expect(networkTime).toBe(2);  // Duration millis
-    const clientNavStartInEpochMillis =
-        serverNavFetchStartEpochMillis - networkTime / 2;
-    expect(clientNavStartInEpochMillis).toBe(1500000000999);
-    const perfOriginInEpochMillis =
-        clientNavStartInEpochMillis - clientNavFetchStartInPerfTime;
-    expect(perfOriginInEpochMillis).toBe(1500000000989);
-
-    expect(getPerfTimeOrigin()).toBe(perfOriginInEpochMillis);
-  });
-});
-
-describe('getDateForPerfTime', () => {
-  it('calculates date for perf time based on time origin', () => {
-    spyOnProperty(performance, 'timeOrigin').and.returnValue(1548000000000);
-
-    expect(getDateForPerfTime(999.6).getTime()).toBe(1548000000999);
-  });
-});
-
-describe('getIsoDateStrForPerfTime', () => {
-  it('converts perf time to nanosecond-precise ISO date string', () => {
-    spyOnProperty(performance, 'timeOrigin').and.returnValue(1535683887001);
-    expect(getIsoDateStrForPerfTime(0.000001))
-        .toEqual('2018-08-31T02:51:27.001000001Z');
+  describe('getDateForPerfTime', () => {
+    it('calculates date for perf time based on time origin', () => {
+      mockGetterOrValue(performance, 'timeOrigin', 1548000000000);
+      expect(getDateForPerfTime(999.6).getTime()).toBe(1548000000999);
+    });
   });
 
-  it('accurately combines milliseconds from origin and perf times', () => {
-    spyOnProperty(performance, 'timeOrigin').and.returnValue(1535683887441.586);
+  describe('getIsoDateStrForPerfTime', () => {
+    it('converts perf time to nanosecond-precise ISO date string', () => {
+      mockGetterOrValue(performance, 'timeOrigin', 1535683887001);
+      expect(getIsoDateStrForPerfTime(0.000001))
+          .toEqual('2018-08-31T02:51:27.001000001Z');
+    });
 
-    expect(getIsoDateStrForPerfTime(658867.8000000073))
-        .toEqual('2018-08-31T03:02:26.309385938Z');
+    it('accurately combines milliseconds from origin and perf times', () => {
+      mockGetterOrValue(performance, 'timeOrigin', 1535683887441.586);
+      expect(getIsoDateStrForPerfTime(658867.8000000073))
+          .toEqual('2018-08-31T03:02:26.309385938Z');
+    });
   });
 });

--- a/packages/opencensus-web-core/test/util.ts
+++ b/packages/opencensus-web-core/test/util.ts
@@ -1,0 +1,64 @@
+/**
+ * Copyright 2019, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** Enables setting arbitrary properties on an object. */
+interface IndexableObject {
+  [key: string]: unknown;
+}
+
+/**
+ * This mocks an object value that can either be a getter property, or just a
+ * regular object value. The reason this is needed it because certain browser
+ * APIs (such as `performance.timeOrigin`) may be modeled as a getter in some
+ * browsers but not in others.
+ *
+ * If the property is a getter, this will use Jasmine's `spyOnProperty`, and for
+ * normal values it just sets the object property directly to the mock value.
+ *
+ * @param object The object whose property to set with a mock value
+ * @param property Name of the property to set
+ * @mockValue Value to set. Should keep the real value first to restory it with
+ *    `restoreGetterOrValue` below.
+ */
+export function mockGetterOrValue<T>(
+    object: T, property: keyof T, mockValue: unknown) {
+  if (isGetter(object, property)) {
+    spyOnProperty(object, property).and.returnValue(mockValue);
+  } else {
+    // Allow forcing mock values that violate the type signature. This allows
+    // mocking `undefined` for browser APIs that are not available in all
+    // browsers.
+    (object as IndexableObject)[property as string] = mockValue;
+  }
+}
+
+/**
+ * Restores an object's previously mocked property (getter or normal value)
+ * to a real value that was saved before the mocking was done.
+ * This is a no-op for getter properties since Jasmine's `spyOnProperty` is
+ * restored automatically. For normal values, this just sets the value.
+ */
+export function restoreGetterOrValue<T, K extends keyof T>(
+    object: T, property: K, value: T[K]) {
+  if (isGetter(object, property)) return;
+  object[property] = value;
+}
+
+function isGetter<T>(object: T, property: keyof T) {
+  const prototype = Object.getPrototypeOf(object);
+  const descriptor = Object.getOwnPropertyDescriptor(prototype, property);
+  return descriptor && descriptor.hasOwnProperty('get');
+}

--- a/packages/opencensus-web-exporter-ocagent/test/test-adapters.ts
+++ b/packages/opencensus-web-exporter-ocagent/test/test-adapters.ts
@@ -19,6 +19,7 @@ import * as webTypes from '@opencensus/web-core';
 import {adaptRootSpan} from '../src/adapters';
 import * as apiTypes from '../src/api-types';
 import {MockRootSpan, MockSpan} from './mock-trace-types';
+import {mockGetterOrValue, restoreGetterOrValue} from './util';
 
 const API_SPAN_KIND_UNSPECIFIED: apiTypes.SpanKindUnspecified = 0;
 const API_SPAN_KIND_SERVER: apiTypes.SpanKindServer = 1;
@@ -26,6 +27,14 @@ const API_LINK_TYPE_CHILD_LINKED_SPAN: apiTypes.LinkTypeChildLinkedSpan = 1;
 const API_MESSAGE_EVENT_TYPE_SENT: apiTypes.MessageEventTypeSent = 1;
 
 describe('Core to API Span adapters', () => {
+  let realTimeOrigin: number;
+  beforeEach(() => {
+    realTimeOrigin = performance.timeOrigin;
+  });
+  afterEach(() => {
+    restoreGetterOrValue(performance, 'timeOrigin', realTimeOrigin);
+  });
+
   it('adapts @opencensus/core span to grpc-gateway properties', () => {
     const coreRootSpan: coreTypes.RootSpan = new MockRootSpan(
         {
@@ -173,7 +182,7 @@ describe('Core to API Span adapters', () => {
   });
 
   it('adapts perf times of web spans as high-res timestamps', () => {
-    spyOnProperty(performance, 'timeOrigin').and.returnValue(1548000000000);
+    mockGetterOrValue(performance, 'timeOrigin', 1548000000000);
     const tracer = new webTypes.Tracer();
     const webSpan1 = new webTypes.Span();
     webSpan1.id = '000000000000000a';

--- a/packages/opencensus-web-exporter-ocagent/test/util.ts
+++ b/packages/opencensus-web-exporter-ocagent/test/util.ts
@@ -1,0 +1,64 @@
+/**
+ * Copyright 2019, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** Enables setting arbitrary properties on an object. */
+interface IndexableObject {
+  [key: string]: unknown;
+}
+
+/**
+ * This mocks an object value that can either be a getter property, or just a
+ * regular object value. The reason this is needed it because certain browser
+ * APIs (such as `performance.timeOrigin`) may be modeled as a getter in some
+ * browsers but not in others.
+ *
+ * If the property is a getter, this will use Jasmine's `spyOnProperty`, and for
+ * normal values it just sets the object property directly to the mock value.
+ *
+ * @param object The object whose property to set with a mock value
+ * @param property Name of the property to set
+ * @mockValue Value to set. Should keep the real value first to restory it with
+ *    `restoreGetterOrValue` below.
+ */
+export function mockGetterOrValue<T>(
+    object: T, property: keyof T, mockValue: unknown) {
+  if (isGetter(object, property)) {
+    spyOnProperty(object, property).and.returnValue(mockValue);
+  } else {
+    // Allow forcing mock values that violate the type signature. This allows
+    // mocking `undefined` for browser APIs that are not available in all
+    // browsers.
+    (object as IndexableObject)[property as string] = mockValue;
+  }
+}
+
+/**
+ * Restores an object's previously mocked property (getter or normal value)
+ * to a real value that was saved before the mocking was done.
+ * This is a no-op for getter properties since Jasmine's `spyOnProperty` is
+ * restored automatically. For normal values, this just sets the value.
+ */
+export function restoreGetterOrValue<T, K extends keyof T>(
+    object: T, property: K, value: T[K]) {
+  if (isGetter(object, property)) return;
+  object[property] = value;
+}
+
+function isGetter<T>(object: T, property: keyof T) {
+  const prototype = Object.getPrototypeOf(object);
+  const descriptor = Object.getOwnPropertyDescriptor(prototype, property);
+  return descriptor && descriptor.hasOwnProperty('get');
+}

--- a/packages/opencensus-web-instrumentation-perf/package-lock.json
+++ b/packages/opencensus-web-instrumentation-perf/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "@opencensus/web-core",
+  "name": "@opencensus/web-instrumentation-perf",
   "version": "0.0.1",
   "lockfileVersion": 1,
   "requires": true,
@@ -156,19 +156,6 @@
           "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
           "dev": true
         }
-      }
-    },
-    "@opencensus/core": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/@opencensus/core/-/core-0.0.8.tgz",
-      "integrity": "sha512-yUFT59SFhGMYQgX0PhoTR0LBff2BEhPrD9io1jWfF/VDbakRfs6Pq60rjv0Z7iaTav5gQlttJCX2+VPxFWCuoQ==",
-      "dev": true,
-      "requires": {
-        "continuation-local-storage": "^3.2.1",
-        "log-driver": "^1.2.7",
-        "semver": "^5.5.0",
-        "shimmer": "^1.2.0",
-        "uuid": "^3.2.1"
       }
     },
     "@types/jasmine": {
@@ -618,16 +605,6 @@
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
       "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==",
       "dev": true
-    },
-    "async-listener": {
-      "version": "0.6.10",
-      "resolved": "https://registry.npmjs.org/async-listener/-/async-listener-0.6.10.tgz",
-      "integrity": "sha512-gpuo6xOyF4D5DE5WvyqZdPA3NGhiT6Qf07l7DCB0wwDEsLvDIbCr6j9S5aj5Ch96dLace5tXVzWBZkxU/c5ohw==",
-      "dev": true,
-      "requires": {
-        "semver": "^5.3.0",
-        "shimmer": "^1.1.0"
-      }
     },
     "atob": {
       "version": "2.1.2",
@@ -1514,16 +1491,6 @@
       "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
       "dev": true
     },
-    "continuation-local-storage": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/continuation-local-storage/-/continuation-local-storage-3.2.1.tgz",
-      "integrity": "sha512-jx44cconVqkCEEyLSKWwkvUXwO561jXMa3LPjTPsm5QR22PA0/mhe33FT4Xb5y74JDvt/Cq+5lm8S8rskLv9ZA==",
-      "dev": true,
-      "requires": {
-        "async-listener": "^0.6.0",
-        "emitter-listener": "^1.1.1"
-      }
-    },
     "convert-source-map": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
@@ -1913,15 +1880,6 @@
         "inherits": "^2.0.1",
         "minimalistic-assert": "^1.0.0",
         "minimalistic-crypto-utils": "^1.0.0"
-      }
-    },
-    "emitter-listener": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/emitter-listener/-/emitter-listener-1.1.2.tgz",
-      "integrity": "sha512-Bt1sBAGFHY9DKY+4/2cV6izcKJUf5T7/gkdmkxzX/qv9CcGH8xSwVRW5mtX03SWJtRTWSOpzCuWN9rBFYZepZQ==",
-      "dev": true,
-      "requires": {
-        "shimmer": "^1.2.0"
       }
     },
     "emojis-list": {
@@ -3764,12 +3722,6 @@
       "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
       "dev": true
     },
-    "log-driver": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.7.tgz",
-      "integrity": "sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg==",
-      "dev": true
-    },
     "log4js": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/log4js/-/log4js-3.0.6.tgz",
@@ -5343,12 +5295,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
-      "dev": true
-    },
-    "shimmer": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.0.tgz",
-      "integrity": "sha512-xTCx2vohXC2EWWDqY/zb4+5Mu28D+HYNSOuFzsyRDRvI/e1ICb69afwaUwfjr+25ZXldbOLyp+iDUZHq8UnTag==",
       "dev": true
     },
     "signal-exit": {


### PR DESCRIPTION
The build for https://github.com/census-instrumentation/opencensus-web/pull/15 ([CircleCi link](https://circleci.com/gh/census-instrumentation/opencensus-web/78)) is failing with a mysterious `Received 'killed' signal` message.

Googling around, I found this thread: [Tests get killed with mysterious “Received ‘killed’ signal” message](https://discuss.circleci.com/t/tests-get-killed-with-mysterious-received-killed-signal-message/22855)

It suggested upgrading to the `machine` build type, which has more memory. This works, but for some reason the browser in the `machine` build type models `performance.timeOrigin` as a regular value not a getter property. So I introduced some helper functions to enable mocking it in browser contexts that model it one way or another so that tests can pass both locally and in CircleCI.

That helper is in a `util.ts` file in two packages - since it's not too complex, I think the duplication is better than trying to create a separate package just for the testing helper.