### PR TITLE
Script to copy types from `@opencensus/core`

### DIFF
--- a/packages/opencensus-web-types/scripts/copy-types.js
+++ b/packages/opencensus-web-types/scripts/copy-types.js
@@ -1,0 +1,140 @@
+/**
+ * Copyright 2018, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview This script copies (and lightly pathces) type definitions from
+ * the @opencensus/core package. This allows sharing types with @opencensus/core
+ * without directly depending on it as an NPM package, which is tricky because
+ * @opencensus/core pulls in various Node-specific dependencies.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const process = require('process');
+const util = require('util');
+
+const exec = util.promisify(require('child_process').exec);
+const mkdtemp = util.promisify(fs.mkdtemp);
+const readFile = util.promisify(fs.readFile);
+const writeFile = util.promisify(fs.writeFile);
+
+/** List of files in the @opencensus/core `src` folder to copy over. */
+const FILES_TO_COPY = [
+  'common/types.ts',
+  'exporters/types.ts',
+  'metrics/export/types.ts',
+  'stats/types.ts',
+  'tags/tag-map.ts',
+  'tags/types.ts',
+  'tags/validation.ts',
+  'trace/config/types.ts',
+  'trace/instrumentation/types.ts',
+  'trace/model/types.ts',
+  'trace/propagation/types.ts',
+  'trace/sampler/types.ts',
+  'trace/types.ts',
+];
+
+const OPENCENSUS_NODE_URL =
+    'http://github.com/census-instrumentation/opencensus-node';
+
+copyFiles();
+
+async function copyFiles() {
+  if (process.argv.length < 3) {
+    throw new Error(
+        'Must specify git tag of `@opencensus/core` copy types from.');
+  }
+  const openCensusNodeTag = process.argv[2];
+
+  console.log('Copying types from @opencensus/node package ...');
+
+  // Clone and checkout the @opencensus/core repo in a temp directory.
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), 'opencensus-core-'));
+  console.log(`Cloning to temp directory: ${tempDir}`);
+  await execAndLog(`git clone ${OPENCENSUS_NODE_URL}`, {cwd: tempDir});
+  const srcDir =
+      path.join(tempDir, 'opencensus-node/packages/opencensus-core/src');
+  await execAndLog(`git checkout ${openCensusNodeTag}`, {cwd: srcDir});
+
+  console.log('Patching and copying type files ...');
+  const destDir = path.join(__dirname, '../src');
+
+  for (const srcFile of FILES_TO_COPY) {
+    const srcPath = path.join(srcDir, srcFile);
+    const destPath = path.join(destDir, srcFile);
+
+    console.log(`Processing ${srcFile} ...`);
+    const contents = await readFile(srcPath, {encoding: 'utf8'});
+    const patchedContents = getPatchedContents(srcFile, contents);
+    await exec(`mkdir -p ${path.dirname(destPath)}`);
+    await writeFile(destPath, patchedContents);
+    console.log(`  Wrote ${destPath}`);
+  }
+}
+
+async function execAndLog(cmd, options) {
+  console.log(cmd);
+  return exec(cmd, options);
+}
+
+function getPatchedContents(srcFile, contents) {
+  contents = updateCopyright(srcFile, contents);
+  contents = fixNodeJsEventEmitterType(srcFile, contents);
+  return contents;
+}
+
+function updateCopyright(srcFile, contents) {
+  const curYear = new Date().getFullYear();
+  const curYearCopyright = `Copyright ${curYear}`;
+  if (contents.indexOf(curYearCopyright) > -1) {
+    return contents;
+  }
+  console.log(`  Updating copyright year for: ${srcFile}`);
+  return contents.replace(/Copyright \d{4}/, curYearCopyright);
+}
+
+/**
+ * Replaces the `NodeJS.EventEmitter` type with a polyfilled
+ * `NodeJsEventEmitter` type and includes an `import` line for it. This allows
+ * removing the `@types/node` dependency to compile.
+ */
+function fixNodeJsEventEmitterType(srcFile, contents) {
+  if (contents.indexOf('NodeJS.EventEmitter') === -1) {
+    return contents;
+  }
+
+  console.log(`  Using NodeJS.EventEmitter polyfill type for: ${srcFile}`);
+
+  contents = contents.replace(/NodeJS.EventEmitter/g, 'NodeJsEventEmitter');
+  const lines = contents.split('\n');
+  let lastImportLine = lines.length - 1;
+  while (lastImportLine > 0 && lines[lastImportLine].indexOf('import ') !== 0) {
+    lastImportLine--;
+  }
+
+  const srcDirDepth = srcFile.length - srcFile.replace(/\//g, '').length;
+  const relativeSrcDir = '../'.repeat(srcDirDepth);
+
+  lines.splice(
+      lastImportLine + 1, 0,
+      `import {NodeJsEventEmitter} from '${relativeSrcDir}node/types';`);
+  contents = lines.join('\n');
+  return contents;
+}

--- a/packages/opencensus-web-types/scripts/copy-types.js
+++ b/packages/opencensus-web-types/scripts/copy-types.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018, OpenCensus Authors
+ * Copyright 2019, OpenCensus Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 
 /**
- * @fileoverview This script copies (and lightly pathces) type definitions from
+ * @fileoverview This script copies (and lightly patches) type definitions from
  * the @opencensus/core package. This allows sharing types with @opencensus/core
  * without directly depending on it as an NPM package, which is tricky because
  * @opencensus/core pulls in various Node-specific dependencies.
@@ -59,7 +59,7 @@ copyFiles();
 async function copyFiles() {
   if (process.argv.length < 3) {
     throw new Error(
-        'Must specify git tag of `@opencensus/core` copy types from.');
+        'Must specify git tag of @opencensus/core copy types from.');
   }
   const openCensusNodeTag = process.argv[2];
 
@@ -68,10 +68,10 @@ async function copyFiles() {
   // Clone and checkout the @opencensus/core repo in a temp directory.
   const tempDir = await mkdtemp(path.join(os.tmpdir(), 'opencensus-core-'));
   console.log(`Cloning to temp directory: ${tempDir}`);
-  await execAndLog(`git clone ${OPENCENSUS_NODE_URL}`, {cwd: tempDir});
+  await logAndExec(`git clone ${OPENCENSUS_NODE_URL}`, {cwd: tempDir});
   const srcDir =
       path.join(tempDir, 'opencensus-node/packages/opencensus-core/src');
-  await execAndLog(`git checkout ${openCensusNodeTag}`, {cwd: srcDir});
+  await logAndExec(`git checkout ${openCensusNodeTag}`, {cwd: srcDir});
 
   console.log('Patching and copying type files ...');
   const destDir = path.join(__dirname, '../src');
@@ -89,7 +89,7 @@ async function copyFiles() {
   }
 }
 
-async function execAndLog(cmd, options) {
+async function logAndExec(cmd, options) {
   console.log(cmd);
   return exec(cmd, options);
 }

--- a/packages/opencensus-web-types/src/node/types.ts
+++ b/packages/opencensus-web-types/src/node/types.ts
@@ -1,0 +1,42 @@
+/**
+ * Copyright 2019, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * NodeJS.EventEmitter type included here so that this package does not
+ * need to take a dependency on the Node typings.
+ * See:
+ * https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/events.d.ts
+ */
+// tslint:disable:no-any Follows DefinintelyTyped `any` types.
+export interface NodeJsEventEmitter {
+  addListener(event: string|symbol, listener: (...args: any[]) => void): this;
+  on(event: string|symbol, listener: (...args: any[]) => void): this;
+  once(event: string|symbol, listener: (...args: any[]) => void): this;
+  removeListener(event: string|symbol, listener: (...args: any[]) => void):
+      this;
+  removeAllListeners(event?: string|symbol): this;
+  setMaxListeners(n: number): this;
+  getMaxListeners(): number;
+  listeners(event: string|symbol): Function[];
+  emit(event: string|symbol, ...args: any[]): boolean;
+  listenerCount(type: string|symbol): number;
+  // Added in Node 6...
+  prependListener(event: string|symbol, listener: (...args: any[]) => void):
+      this;
+  prependOnceListener(event: string|symbol, listener: (...args: any[]) => void):
+      this;
+  eventNames(): Array<string|symbol>;
+}


### PR DESCRIPTION
This script copies in the type files from `@opencensus/core` to avoid the dependency issues described in https://github.com/census-instrumentation/opencensus-web/blob/master/packages/opencensus-web-types/README.md

This also brings in the polyfill for the `NodeJS.EventEmitter` type so that no dependency on `@types/node` is needed.