### PR TITLE
Add renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,19 @@
+{
+  "extends": [
+    "config:base",
+    "docker:disable"
+  ],
+  "pinVersions": false,
+  "rebaseStalePrs": true,
+  "timezone": "America/New_York",
+  "schedule": [
+    "after 9am and before 3pm"
+  ],
+  "gitAuthor": null,
+  "packageRules": [
+    {
+      "extends": "packages:linters",
+      "groupName": "linters"
+    }
+  ]
+}


### PR DESCRIPTION
This is for https://github.com/census-instrumentation/opencensus-web/issues/32. Once this is committed, we can turn on Renovate for the repo.