### PR TITLE
Switch to use Node 11 CircleCI docker environment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,18 +11,13 @@ release_tags: &release_tags
 version: 2.0
 jobs:
   build:
-    machine: true
+    docker:
+      - image: circleci/node:11-browsers
     steps:
       - checkout
       - run:
           name: Install modules and dependencies.
           command: npm install
-      - run:
-          name: Check code style and linting
-          command: npm run check
-      - run:
-          name: Ensure code compiles to JS.
-          command: npm run compile
       - run:
           name: Run unit tests.
           command: npm run test


### PR DESCRIPTION
This will enable upgrading Karma to v4 in https://github.com/census-instrumentation/opencensus-web/pull/42, because Karma v4 stopped Node 6 support (by introducing async/await) and it seems the default version on the CircleCI `machine` type supports an old Node version.

Because the `npm test` script also runs the compile and checks, this also removes those separate runs to make the overall build take less time. In the future I may find a clever way to avoid the duplication and put them back.