### PR TITLE
Rename globals prefix from `ocw` to `oc`

### DIFF
--- a/examples/initial_load/index.html
+++ b/examples/initial_load/index.html
@@ -23,7 +23,7 @@
 
     <script>
       traceparent = "{{.Traceparent}}";
-      ocwAgent = "http://{{.AgentHostAndPort}}";
+      ocAgent = "http://{{.AgentHostAndPort}}";
     </script>
     <script src="{{.OcwScriptEndpoint}}/initial-load-all.js" async></script>
     <footer>

--- a/packages/opencensus-web-all/src/export-initial-load.ts
+++ b/packages/opencensus-web-all/src/export-initial-load.ts
@@ -35,17 +35,17 @@ const TRACE_ENDPOINT = '/v1/trace';
 
 /**
  * Waits until after the document `load` event fires, and then uses the
- * `window.ocwAgent` setting to configure an OpenCensus agent exporter and
+ * `window.ocAgent` setting to configure an OpenCensus agent exporter and
  * export the spans for the initial page load.
  */
 export function exportRootSpanAfterLoadEvent() {
-  if (!windowWithOcwGlobals.ocwAgent) {
+  if (!windowWithOcwGlobals.ocAgent) {
     console.log('Not configured to export page load spans.');
     return;
   }
 
   tracing.registerExporter(new OCAgentExporter(
-      {agentEndpoint: `${windowWithOcwGlobals.ocwAgent}${TRACE_ENDPOINT}`}));
+      {agentEndpoint: `${windowWithOcwGlobals.ocAgent}${TRACE_ENDPOINT}`}));
 
   if (document.readyState === 'complete') {
     exportInitialLoadSpans();

--- a/packages/opencensus-web-all/src/types.ts
+++ b/packages/opencensus-web-all/src/types.ts
@@ -22,7 +22,7 @@ export declare interface WindowWithOcwGlobals extends WindowWithLongTasks {
    * HTTP root URL of the agent endpoint to write traces to.
    * Example 'https://my-oc-agent-deployment.com:55678'
    */
-  ocwAgent?: string;
+  ocAgent?: string;
   /**
    * For the initial page load, web browsers do not send any custom headers,
    * which means that the server will not receive trace context headers.
@@ -46,5 +46,5 @@ export declare interface WindowWithOcwGlobals extends WindowWithLongTasks {
    * exports it can be in different JS bundles. This enables deferring loading
    * the export code until it is needed.
    */
-  ocwLt?: PerformanceLongTaskTiming[];
+  ocLt?: PerformanceLongTaskTiming[];
 }

--- a/packages/opencensus-web-all/test/test-export-initial-load.ts
+++ b/packages/opencensus-web-all/test/test-export-initial-load.ts
@@ -46,17 +46,17 @@ describe('exportRootSpanAfterLoadEvent', () => {
     spyOn(XMLHttpRequest.prototype, 'open');
     sendSpy = spyOn(XMLHttpRequest.prototype, 'send');
     spyOn(XMLHttpRequest.prototype, 'setRequestHeader');
-    realOcwAgent = windowWithOcwGlobals.ocwAgent;
+    realOcwAgent = windowWithOcwGlobals.ocAgent;
     realTraceparent = windowWithOcwGlobals.traceparent;
   });
   afterEach(() => {
     jasmine.clock().uninstall();
-    windowWithOcwGlobals.ocwAgent = realOcwAgent;
+    windowWithOcwGlobals.ocAgent = realOcwAgent;
     windowWithOcwGlobals.traceparent = realTraceparent;
   });
 
   it('exports spans to agent if agent is configured', () => {
-    windowWithOcwGlobals.ocwAgent = 'http://agent';
+    windowWithOcwGlobals.ocAgent = 'http://agent';
     windowWithOcwGlobals.traceparent = undefined;
 
     exportRootSpanAfterLoadEvent();
@@ -68,7 +68,7 @@ describe('exportRootSpanAfterLoadEvent', () => {
   });
 
   it('does not export if agent not configured', () => {
-    windowWithOcwGlobals.ocwAgent = undefined;
+    windowWithOcwGlobals.ocAgent = undefined;
     windowWithOcwGlobals.traceparent = undefined;
 
     exportRootSpanAfterLoadEvent();
@@ -79,7 +79,7 @@ describe('exportRootSpanAfterLoadEvent', () => {
   });
 
   it('uses trace and span ID from window.traceparent if specified', () => {
-    windowWithOcwGlobals.ocwAgent = 'http://agent';
+    windowWithOcwGlobals.ocAgent = 'http://agent';
     const traceId = '0af7651916cd43dd8448eb211c80319c';
     const spanId = 'b7ad6b7169203331';
     windowWithOcwGlobals.traceparent = `00-${traceId}-${spanId}-01`;
@@ -97,7 +97,7 @@ describe('exportRootSpanAfterLoadEvent', () => {
   });
 
   it('does not export spans if traceparent sampling hint not set', () => {
-    windowWithOcwGlobals.ocwAgent = 'http://agent';
+    windowWithOcwGlobals.ocAgent = 'http://agent';
     windowWithOcwGlobals.traceparent =
         '00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-00';
 

--- a/packages/opencensus-web-instrumentation-perf/src/long-tasks-recorder.ts
+++ b/packages/opencensus-web-instrumentation-perf/src/long-tasks-recorder.ts
@@ -16,7 +16,7 @@
 
 import {PerformanceLongTaskTiming, PerformanceObserverEntryList, WindowWithLongTasks} from './perf-types';
 
-/** Cast `window` to be access the `ocwLt` field for long task timings.  */
+/** Cast `window` to be access the `ocLt` field for long task timings.  */
 const windowWithLongTasks = window as WindowWithLongTasks;
 
 /**
@@ -30,12 +30,12 @@ export function recordLongTasks() {
         new windowWithLongTasks.PerformanceObserver(onLongTasks);
     longTaskObserver.observe({entryTypes: ['longtask']});
   }
-  windowWithLongTasks.ocwLt = [];
+  windowWithLongTasks.ocLt = [];
 }
 
 function onLongTasks(entryList: PerformanceObserverEntryList) {
   // These must be PerformanceLongTaskTiming objects because we only observe
   // 'longtask' above.
-  windowWithLongTasks.ocwLt!.push(
+  windowWithLongTasks.ocLt!.push(
       ...(entryList.getEntries() as PerformanceLongTaskTiming[]));
 }

--- a/packages/opencensus-web-instrumentation-perf/src/perf-grouper.ts
+++ b/packages/opencensus-web-instrumentation-perf/src/perf-grouper.ts
@@ -16,7 +16,7 @@
 
 import {PerformanceLongTaskTiming, PerformanceNavigationTimingExtended, PerformancePaintTiming, PerformanceResourceTimingExtended, WindowWithLongTasks} from './perf-types';
 
-/** Cast `window` to be access the `ocwLt` field for long task timings.  */
+/** Cast `window` to be access the `ocLt` field for long task timings.  */
 const windowWithLongTasks = window as WindowWithLongTasks;
 
 /** Represent all collected performance timings grouped by type. */
@@ -39,7 +39,7 @@ export function getPerfEntries(): GroupedPerfEntries {
 
   const perf = window.performance;
 
-  const longTaskTimings = windowWithLongTasks.ocwLt;
+  const longTaskTimings = windowWithLongTasks.ocLt;
 
   const entries: GroupedPerfEntries = {
     resourceTimings: perf.getEntriesByType('resource') as
@@ -60,7 +60,7 @@ export function getPerfEntries(): GroupedPerfEntries {
 /** Clears resource timings, marks, measures and stored long task timings. */
 export function clearPerfEntries() {
   if (!window.performance) return;
-  windowWithLongTasks.ocwLt = [];
+  windowWithLongTasks.ocLt = [];
   performance.clearResourceTimings();
   performance.clearMarks();
   performance.clearMeasures();

--- a/packages/opencensus-web-instrumentation-perf/src/perf-types.ts
+++ b/packages/opencensus-web-instrumentation-perf/src/perf-types.ts
@@ -162,5 +162,5 @@ export declare interface PerformanceLongTaskTiming extends PerformanceEntry {
 /** Type for the `window` object with a field to track LongTask timings. */
 export declare interface WindowWithLongTasks extends Window {
   readonly PerformanceObserver?: PerformanceObserver;
-  ocwLt?: PerformanceLongTaskTiming[];
+  ocLt?: PerformanceLongTaskTiming[];
 }


### PR DESCRIPTION
This renames the global variables that OpenCensus web expects on the window (besides `traceparent`) to have an `oc` prefix rather than `ocw` prefix, which is slightly shorter and for `ocAgent` seems to fit better (it's the "OpenCensus Agent" but not the "OpenCensus Web Agent").