### PR TITLE
Sent OC Web library type and version to OC agent

### DIFF
--- a/packages/opencensus-web-core/src/index.ts
+++ b/packages/opencensus-web-core/src/index.ts
@@ -21,6 +21,7 @@ export {Tracer} from './trace/model/tracer';
 export {Tracing} from './trace/model/tracing';
 export * from './trace/model/util';
 export * from './trace/model/attribute-keys';
+export {VERSION} from './version';
 
 // Re-export types this uses from @opencensus/web-types.
 export {Annotation, Attributes, BufferConfig, CanonicalCode, Config, Exporter, ExporterConfig, HeaderGetter, HeaderSetter, Link, LinkType, Logger, MessageEvent, MessageEventType, Propagation, SpanContext, SpanEventListener, SpanKind, Status, TracerConfig, TraceState} from '@opencensus/web-types';

--- a/packages/opencensus-web-core/src/version.ts
+++ b/packages/opencensus-web-core/src/version.ts
@@ -15,7 +15,7 @@
  */
 
 /**
- * The version of the @opencensus/web-exporter-ocagent library. This will be
- * sent as metadata with the written traces.
+ * The version of the @opencensus/web-core library. This is sent as metadata
+ * with the written traces by the @opencensus/web-exporter-ocagent library.
  */
-export const EXPORTER_VERSION = '0.0.1';
+export const VERSION = '0.0.1';

--- a/packages/opencensus-web-exporter-ocagent/src/api-types.ts
+++ b/packages/opencensus-web-exporter-ocagent/src/api-types.ts
@@ -66,14 +66,26 @@ export interface Node {
   attributes?: {[key: string]: string};
 }
 
-export interface LibraryInfo {
-  /**
-   * TODO(draffensperger): Get additional language option for web JavaScript,
-   * and then set the library version here.
-   */
+/** Unspecified library info language. */
+export type LanguageUnspecified = 0;
+/** Indicates that the spans were created by OpenCensus Web. */
+export type LanguageWebJs = 10;
+/**
+ * OpenCensus language used to create the spans. Most of the options are
+ * omitted since the spans produced by OpenCensus Web are always from the Web JS
+ * library.
+ */
+export type LibraryInfoLanguage = LanguageUnspecified|LanguageWebJs;
 
+/** Information on OpenCensus library that produced the spans/metrics. */
+export interface LibraryInfo {
+  /** Language of OpenCensus Library. */
+  language?: LibraryInfoLanguage;
+
+  /** Version of Agent exporter of Library. */
   exporterVersion?: string;
 
+  /** Version of OpenCensus Library. */
   coreLibraryVersion?: string;
 }
 

--- a/packages/opencensus-web-exporter-ocagent/src/ocagent.ts
+++ b/packages/opencensus-web-exporter-ocagent/src/ocagent.ts
@@ -14,12 +14,19 @@
  * limitations under the License.
  */
 
-import {Exporter, ExporterConfig, RootSpan} from '@opencensus/web-core';
+import {Exporter, ExporterConfig, RootSpan, VERSION} from '@opencensus/web-core';
 
 import {adaptRootSpan} from './adapters';
 import * as apiTypes from './api-types';
 import {ExporterBuffer} from './exporter-buffer';
 import {EXPORTER_VERSION} from './version';
+
+/**
+ * Enum value for LibraryInfo.Language that indicates to the OpenCensus Agent
+ * that the generated spans/metrics are from the Web JS OpenCensus libary. See:
+ * https://github.com/census-instrumentation/opencensus-proto/blob/master/src/opencensus/proto/agent/common/v1/common.proto
+ */
+const WEB_JS_LIBRARY_LANGUAGE: apiTypes.LanguageWebJs = 10;
 
 // The value of XMLHttpRequest `readyState` property when the request is done.
 const XHR_READY_STATE_DONE = 4;
@@ -98,9 +105,9 @@ export class OCAgentExporter implements Exporter {
       identifier: {hostName: location.host},
       serviceInfo: {name: this.config.serviceName},
       libraryInfo: {
+        language: WEB_JS_LIBRARY_LANGUAGE,
         exporterVersion: EXPORTER_VERSION,
-        // TODO(draffensperger): Set coreLibraryVersion here once there is an
-        // OpenCensus web core library established.
+        coreLibraryVersion: VERSION,
       },
       attributes: this.config.attributes,
     };

--- a/packages/opencensus-web-exporter-ocagent/test/test-ocagent.ts
+++ b/packages/opencensus-web-exporter-ocagent/test/test-ocagent.ts
@@ -18,6 +18,8 @@ import * as webCore from '@opencensus/web-core';
 
 import {OCAgentExporter} from '../src';
 import * as apiTypes from '../src/api-types';
+import {EXPORTER_VERSION} from '../src/version';
+
 import {mockGetterOrValue, restoreGetterOrValue} from './util';
 
 const BUFFER_SIZE = 1;
@@ -109,8 +111,8 @@ describe('OCAgentExporter', () => {
         serviceInfo: {name: 'testService'},
         libraryInfo: {
           language: 10,
-          coreLibraryVersion: '0.0.1',
-          exporterVersion: '0.0.1',
+          coreLibraryVersion: webCore.VERSION,
+          exporterVersion: EXPORTER_VERSION,
         },
         attributes: {serviceAddr1: 'a'},
       },

--- a/packages/opencensus-web-exporter-ocagent/test/test-ocagent.ts
+++ b/packages/opencensus-web-exporter-ocagent/test/test-ocagent.ts
@@ -107,7 +107,11 @@ describe('OCAgentExporter', () => {
       node: {
         identifier: {hostName: window.location.host},
         serviceInfo: {name: 'testService'},
-        libraryInfo: {exporterVersion: '0.0.1'},
+        libraryInfo: {
+          language: 10,
+          coreLibraryVersion: '0.0.1',
+          exporterVersion: '0.0.1',
+        },
         attributes: {serviceAddr1: 'a'},
       },
       spans: apiSpans,


### PR DESCRIPTION
This will enable the OpenCensus Agent's Stackdriver Exporter to write the `g.co/agent` label to the exported traces.

Fixes https://github.com/census-instrumentation/opencensus-web/issues/49