### PR TITLE
Add sample rate option and update README for it

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,22 +55,26 @@ it from the `/static` folder of your site.
 Once the OpenCensus Web packages are released to NPM, you will also be able to
 include them in your JavaScript build pipeline as an imported dependency.
 
-In order to indicate the endpoint of the OpenCensus Agent so that traces can be
-written, you will need to include a snippet of JavaScript that sets the
-`ocAgent` global variable, for instance:
+In order to indicate the trace sampling rate and endpoint of the OpenCensus 
+Agent so that traces can be written, you will need to include a snippet of 
+JavaScript that sets the `ocAgent` and `ocSampleRate` global variables, 
+for instance:
 
 ```html
-<script>ocAgent = 'https://example.com/my-opencensus-agent-endpoint'</script>
+<script>
+  ocAgent = 'https://example.com/my-opencensus-agent-endpoint';
+  // Sample all requests for trace, which is useful when testing.
+  // By default this is set to sample 1/1000 requests.
+  ocSampleRate = 1.0; 
+</script>
 ```
 
 ### 3. Optional: Send a trace parent and sampling decision from your server
 
-Currently, the OpenCensus Web will sample all requests by default. This is
-useful for experimentation with the library but is not appropriate for a real
-application.
-
 OpenCensus Web also supports connecting the server side spans for the initial
 HTML load with the client side span for the load from the browser's timing API.
+This works by having the server send its parent trace context (trace ID, span ID
+and trace sampling decision) to the client.
 
 Because the browser does not send a trace context header for the initial page
 navigation, the server needs to fake a trace context header in a middleware and

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ for instance:
 <script>
   ocAgent = 'https://example.com/my-opencensus-agent-endpoint';
   // Sample all requests for trace, which is useful when testing.
-  // By default this is set to sample 1/1000 requests.
+  // By default this is set to sample 1/10000 requests.
   ocSampleRate = 1.0; 
 </script>
 ```

--- a/packages/opencensus-web-all/src/initial-load-context.ts
+++ b/packages/opencensus-web-all/src/initial-load-context.ts
@@ -25,7 +25,7 @@ const windowWithOcwGlobals = window as WindowWithOcwGlobals;
  * The default trace sampling rate if no `traceparent` and no `ocSampleRate`
  * are specified on the `window`.
  */
-const DEFAULT_SAMPLE_RATE = 0.001;
+const DEFAULT_SAMPLE_RATE = 0.0001;
 
 /**
  * Gets a span context for the initial page load from the `window.traceparent`,

--- a/packages/opencensus-web-all/src/initial-load-context.ts
+++ b/packages/opencensus-web-all/src/initial-load-context.ts
@@ -22,26 +22,36 @@ import {WindowWithOcwGlobals} from './types';
 const windowWithOcwGlobals = window as WindowWithOcwGlobals;
 
 /**
+ * The default trace sampling rate if no `traceparent` and no `ocSampleRate`
+ * are specified on the `window`.
+ */
+const DEFAULT_SAMPLE_RATE = 0.001;
+
+/**
  * Gets a span context for the initial page load from the `window.traceparent`,
  * or generates a new random span context if it is missing. For now the new
  * random span context generated if `window.traceparent` is missing is always
  * marked sampled.
  */
 export function getInitialLoadSpanContext(): SpanContext {
-  if (!windowWithOcwGlobals.traceparent) return alwaysSampledSpanContext();
+  if (!windowWithOcwGlobals.traceparent) return randomSampledSpanContext();
   const spanContext =
       traceParentToSpanContext(windowWithOcwGlobals.traceparent);
   if (!spanContext) {
     console.log(`Invalid traceparent: ${windowWithOcwGlobals.traceparent}`);
-    return alwaysSampledSpanContext();
+    return randomSampledSpanContext();
   }
   return spanContext;
 }
 
-function alwaysSampledSpanContext() {
+function randomSampledSpanContext() {
+  const sampleRate = windowWithOcwGlobals.ocSampleRate || DEFAULT_SAMPLE_RATE;
   return {
     traceId: randomTraceId(),
     spanId: randomSpanId(),
-    options: 0x1,  // Sampled
+    // Math.random returns a number in the 0-1 range (inclusive of 0 but not 1).
+    // That means we should use the strict `<` operator to compare it to the
+    // sample rate. A value of 1 for `options` indicates trace sampling.
+    options: Math.random() < sampleRate ? 1 : 0,
   };
 }

--- a/packages/opencensus-web-all/src/types.ts
+++ b/packages/opencensus-web-all/src/types.ts
@@ -41,6 +41,12 @@ export declare interface WindowWithOcwGlobals extends WindowWithLongTasks {
    */
   traceparent?: string;
   /**
+   * If the `traceparent` global variable described above is not present on the
+   * `window`, then a trace sampling decision will be made randomly with the
+   * specified sample rate. If not specified, a default sampling rate is used.
+   */
+  ocSampleRate?: number;
+  /**
    * List to collect long task timings as they are observed. This is on the
    * window so that the code to instrument the long tasks and the code that
    * exports it can be in different JS bundles. This enables deferring loading


### PR DESCRIPTION
This will enable the use case when someone wants to only sample some requests but doesn't make their backend server send back the `traceparent` header.

Fixes https://github.com/census-instrumentation/opencensus-web/issues/46