### PR TITLE
NPM release docs and CI tooling

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,11 +8,29 @@ release_tags: &release_tags
   tags:
     only: /^v\d+(\.\d+){2}(-.*)?$/
 
+
+docker_config: &docker_config
+  docker:
+    - image: circleci/node:11-browsers
+
 version: 2.0
+workflows:
+  version: 2
+  test_and_publish:
+    jobs:
+      - test:
+          filters: *release_tags
+      - publish_npm:
+          requires:
+            - test
+          filters:
+            branches:
+              ignore: /.*/
+            <<: *release_tags
+
 jobs:
-  build:
-    docker:
-      - image: circleci/node:11-browsers
+  test:
+    <<: *docker_config
     steps:
       - checkout
       - run:
@@ -25,3 +43,39 @@ jobs:
           name: Submit coverage data to codecov.
           command: npm run codecov
           when: always
+  publish_npm:
+    <<: *docker_config
+    steps:
+      - checkout
+      - run:
+          name: Install modules and dependencies.
+          command: npm install
+      - run:
+          name: Set NPM authentication.
+          # Publish to NPM via the Google wombat bot that manages auth tokens,
+          # so each token has authority to publish to just a single package.
+          command: echo "//wombat-dressing-room.appspot.com/:_authToken=${NPM_TOKEN}" > ~/.npmrc
+      - run: |
+          cd packages/opencensus-web-all
+          NPM_TOKEN="$WOMBAT_TOKEN_ALL"
+          npm publish --registry https://wombat-dressing-room.appspot.com
+      - run: |
+          cd packages/opencensus-web-core
+          NPM_TOKEN="$WOMBAT_TOKEN_CORE"
+          npm publish --registry https://wombat-dressing-room.appspot.com
+      - run: |
+          cd packages/opencensus-web-exporter-ocagent
+          NPM_TOKEN="$WOMBAT_TOKEN_EXPORTER_OCAGENT"
+          npm publish --registry https://wombat-dressing-room.appspot.com
+      - run: |
+          cd packages/opencensus-web-instrumentation-perf
+          NPM_TOKEN="$WOMBAT_TOKEN_INSTRUMENTATION_PERF"
+          npm publish --registry https://wombat-dressing-room.appspot.com
+      - run: |
+          cd packages/opencensus-web-propagation-tracecontext
+          NPM_TOKEN="$WOMBAT_TOKEN_PROPAGATION_TRACECONTEXT"
+          npm publish --registry https://wombat-dressing-room.appspot.com
+      - run: |
+          cd packages/opencensus-web-types
+          NPM_TOKEN="$WOMBAT_TOKEN_TYPES"
+          npm publish --registry https://wombat-dressing-room.appspot.com

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,72 @@
+# Releasing OpenCensus Node Packages (for Maintainers Only)
+
+This document explains how to publish all OC Node modules at version x.y.z.
+Ensure that you’re following [semver][semver-url] when choosing a version number.
+
+## Update to latest locally
+
+Use `git fetch` and `git checkout origin/master` to ensure you’re on the latest
+commit. Make sure you have no unstaged changes. Ideally, also use
+`git clean -dfx` to remove all ignored and untracked files.
+
+## Create a new branch
+
+Create a new branch called `x.y.z-proposal` from the current commit.
+
+## Install packages and run the version bump script
+
+Run `npm install` to make sure the packages are installed and built. Then run
+`npm run bump`, pick the version for `x.y.z`, and enter `y` for 
+`Are you sure you want to publish these packages?` (They will not actually be
+published, just the version will be bumped).
+
+The version bump should create some unstaged changes.
+
+## Create a new commit
+
+Create a new commit with the exact title: `chore(multiple): x.y.z release proposal`.
+
+## Create a draft GitHub Release
+
+On [GitHub Releases][github-releases-url],
+follow the example set by recent releases to populate a summary of changes, as 
+well as a list of commits that were applied since the last release. 
+Running `git log --oneline --no-decorate` is a good way to get that list of
+commits. Save it as a draft, don’t publish it. Don’t forget the tag -- call it 
+`vx.y.z` and leave it pointing at `master` for now (this can be changed as long
+as the GitHub release isn’t published).
+
+## Create a new PR
+
+Push the branch to GitHub and create a new PR with that exact name. The commit
+body should just be a link to the *draft* notes. Someone who can access draft
+notes should approve it, looking in particular for test passing, and whether the
+draft notes are satisfactory.
+
+## Merge and pull
+
+Merge the PR, and pull the changes locally (using the commands in the first 
+step). Ensure that `chore(multiple): x.y.z release proposal` is the most recent
+commit.
+
+## Publish the GitHub Release
+
+Publish the GitHub release, ensuring that the tag points to the newly landed
+commit corresponding to release proposal `x.y.z`.
+
+## NPM publish happens automatically via CircleCI
+
+Publishing the GitHub release will cause the release commit to be tagged as 
+`vx.y.z`, which triggers a CircleCI `publish_npm` job that automatically
+publishes the packages to NPM. See the 
+[OpenCensus Web CircleCI config][oc-web-circleci-url]
+
+## Update CHANGELOG and release versions in examples
+* After releasing, you need to update all examples to the latest version.
+* In addition, update the CHANGELOG.md and start new Unreleased label.
+* Create a new commit with the exact title: `Post Release: update CHANGELOG, Examples and ReadMe`.
+* Go through PR review and merge it to GitHub master branch.
+
+[semver-url]: https://semver.org/
+[github-releases-url]: https://github.com/census-instrumentation/opencensus-web/releases
+[oc-web-circleci-url]: https://github.com/census-instrumentation/opencensus-web/blob/master/.circleci/config.yml

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "compile": "lerna run compile",
     "test": "lerna run test",
     "bootstrap": "lerna bootstrap",
-    "bump": "lerna publish",
+    "bump": "lerna publish  --skip-npm --skip-git",
     "codecov": "lerna run codecov",
     "check": "lerna run check"
   },

--- a/packages/opencensus-web-all/package.json
+++ b/packages/opencensus-web-all/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@opencensus/web-all",
   "version": "0.0.1",
-  "description": "OpenCensus Web All combines all the main OpenCensus Web packages to provide distributions for easy use in web applications via <script> tags.",
+  "description":
+    "OpenCensus Web All combines all the main OpenCensus Web packages to provide distributions for easy use in web applications via <script> tags.",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
   "scripts": {
     "build:prod": "webpack --config ./webpack/prod-bundles.config.js",
     "build:dev": "webpack --config ./webpack/dev-bundles.config.js",
-    "start:webpack-server": "webpack-dev-server --config ./webpack/dev-bundles.config.js",
+    "start:webpack-server":
+      "webpack-dev-server --config ./webpack/dev-bundles.config.js",
     "test": "karma start --single-run",
     "test:start": "karma start",
     "codecov": "codecov -f coverage/*.json",
@@ -17,7 +19,8 @@
     "fix": "gts fix",
     "prepare": "npm run compile",
     "pretest": "npm run compile",
-    "posttest": "npm run check"
+    "posttest": "npm run check",
+    "prepublishOnly": "npm run build:prod"
   },
   "repository": "census-instrumentation/opencensus-web",
   "keywords": [
@@ -71,7 +74,5 @@
     "@opencensus/web-instrumentation-perf": "^0.0.1",
     "@opencensus/web-propagation-tracecontext": "^0.0.1"
   },
-  "sideEffects": [
-    "./src/entrypoints/*.ts"
-  ]
+  "sideEffects": ["./src/entrypoints/*.ts"]
 }


### PR DESCRIPTION
This updates the CircleCI build to enable automated publishing of tagged commits and also fills out a `RELEASING.md`. It also makes the `@opencensus/web-all` build JS bundles in a `prepublishOnly` step.

cc/ @soldair