### PR TITLE
Add JS bundles and source maps to NPM package files

### DIFF
--- a/packages/opencensus-web-all/package.json
+++ b/packages/opencensus-web-all/package.json
@@ -39,6 +39,8 @@
   "files": [
     "build/src/**/*.js",
     "build/src/**/*.d.ts",
+    "dist/*.js",
+    "dist/*.js.map",
     "doc",
     "CHANGELOG.md",
     "LICENSE",


### PR DESCRIPTION
This adds the `dist/*.js` and `dist/*.js.map` files to the files that will be published to NPM. I had mistakenly left them out earlier, which means that the `0.0.1` release did not include them. I'll plan to do a follow-up fix release with them.