### PR TITLE
Fix automatic NPM publish job in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ docker_config: &docker_config
 version: 2.0
 workflows:
   version: 2
-  test_and_publish:
+  build:
     jobs:
       - test:
           filters: *release_tags
@@ -50,32 +50,10 @@ jobs:
       - run:
           name: Install modules and dependencies.
           command: npm install
-      - run:
-          name: Set NPM authentication.
-          # Publish to NPM via the Google wombat bot that manages auth tokens,
-          # so each token has authority to publish to just a single package.
-          command: echo "//wombat-dressing-room.appspot.com/:_authToken=${NPM_TOKEN}" > ~/.npmrc
-      - run: |
-          cd packages/opencensus-web-all
-          NPM_TOKEN="$WOMBAT_TOKEN_ALL"
-          npm publish --registry https://wombat-dressing-room.appspot.com
-      - run: |
-          cd packages/opencensus-web-core
-          NPM_TOKEN="$WOMBAT_TOKEN_CORE"
-          npm publish --registry https://wombat-dressing-room.appspot.com
-      - run: |
-          cd packages/opencensus-web-exporter-ocagent
-          NPM_TOKEN="$WOMBAT_TOKEN_EXPORTER_OCAGENT"
-          npm publish --registry https://wombat-dressing-room.appspot.com
-      - run: |
-          cd packages/opencensus-web-instrumentation-perf
-          NPM_TOKEN="$WOMBAT_TOKEN_INSTRUMENTATION_PERF"
-          npm publish --registry https://wombat-dressing-room.appspot.com
-      - run: |
-          cd packages/opencensus-web-propagation-tracecontext
-          NPM_TOKEN="$WOMBAT_TOKEN_PROPAGATION_TRACECONTEXT"
-          npm publish --registry https://wombat-dressing-room.appspot.com
-      - run: |
-          cd packages/opencensus-web-types
-          NPM_TOKEN="$WOMBAT_TOKEN_TYPES"
-          npm publish --registry https://wombat-dressing-room.appspot.com
+      # Run publish script for each package suffix and its NPM wombat token.
+      - run: .circleci/publish.sh all $WOMBAT_TOKEN_ALL
+      - run: .circleci/publish.sh core $WOMBAT_TOKEN_CORE
+      - run: .circleci/publish.sh exporter-ocagent $WOMBAT_TOKEN_EXPORTER_OCAGENT
+      - run: .circleci/publish.sh instrumentation-perf $WOMBAT_TOKEN_INSTRUMENTATION_PERF
+      - run: .circleci/publish.sh propagation-tracecontext "$WOMBAT_TOKEN_PROPAGATION_TRACECONTEXT"
+      - run: .circleci/publish.sh types "$WOMBAT_TOKEN_TYPES"

--- a/.circleci/publish.sh
+++ b/.circleci/publish.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Copyright 2019, OpenCensus Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Fail the script if any command fails
+set -e
+
+PACKAGE_SUFFIX="$1"
+NPM_TOKEN="$2"
+
+# Print each line of the script but don't expand variables.
+set -v
+
+rm -f ~/.npmrc
+
+# Publish to NPM via the Google wombat bot that manages auth tokens, so each
+# token has authority to publish to just a single package.
+echo "//wombat-dressing-room.appspot.com/:_authToken=${NPM_TOKEN}" > ~/.npmrc
+
+cd "packages/opencensus-web-$PACKAGE_SUFFIX"
+
+npm publish --registry https://wombat-dressing-room.appspot.com

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -45,9 +45,8 @@ draft notes are satisfactory.
 
 ## Merge and pull
 
-Merge the PR, and pull the changes locally (using the commands in the first 
-step). Ensure that `chore(multiple): x.y.z release proposal` is the most recent
-commit.
+Merge the PR, and ensure that `chore(multiple): x.y.z release proposal` is the
+most recent commit.
 
 ## Publish the GitHub Release
 


### PR DESCRIPTION
The previous CircleCI job commands that attempted to automatically publish to NPM didn't work because the `NPM_TOKEN` was just substituted a single time in the `~/.npmrc` file. I fixed this by making a separate script that updates `~/.npmrc` for each package to publish. I've tested it locally and with CircleCI (up to the point where it says "you can't re-publish a package with the same version").