### PR TITLE
Sync @opencensus/web-types to v0.0.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 - Add support for object(`SpanOptions`) as an argument for `startChildSpan` function, similar to `startRootSpan`.
+- Please note that there is an API breaking change in methods `addMessageEvent()`. The field `id` is now number instead of string.
 
 ## 0.0.2 - 2019-04-29
 

--- a/packages/opencensus-web-core/src/trace/model/span.ts
+++ b/packages/opencensus-web-core/src/trace/model/span.ts
@@ -186,7 +186,7 @@ export class Span implements webTypes.Span {
    */
   addMessageEvent(
     type: webTypes.MessageEventType,
-    id: string,
+    id: number,
     timestamp: number = performance.now(),
     uncompressedSize?: number,
     compressedSize?: number

--- a/packages/opencensus-web-core/test/test-span.ts
+++ b/packages/opencensus-web-core/test/test-span.ts
@@ -153,12 +153,12 @@ describe('Span', () => {
 
   describe('addMessageEvent', () => {
     it('adds message event with specified timestamp', () => {
-      span.addMessageEvent(MessageEventType.SENT, 'id22', /* timestamp */ 25);
+      span.addMessageEvent(MessageEventType.SENT, 22, /* timestamp */ 25);
 
       expect(span.messageEvents).toEqual([
         {
           type: MessageEventType.SENT,
-          id: 'id22',
+          id: 22,
           timestamp: 25,
           uncompressedSize: undefined,
           compressedSize: undefined,
@@ -168,12 +168,12 @@ describe('Span', () => {
 
     it('defaults timestamp to performance.now', () => {
       spyOn(performance, 'now').and.returnValue(33);
-      span.addMessageEvent(MessageEventType.RECEIVED, 'id23');
+      span.addMessageEvent(MessageEventType.RECEIVED, 23);
 
       expect(span.messageEvents).toEqual([
         {
           type: MessageEventType.RECEIVED,
-          id: 'id23',
+          id: 23,
           timestamp: 33,
           uncompressedSize: undefined,
           compressedSize: undefined,

--- a/packages/opencensus-web-exporter-ocagent/src/adapters.ts
+++ b/packages/opencensus-web-exporter-ocagent/src/adapters.ts
@@ -114,7 +114,7 @@ function adaptMessageEvent(
     time: adaptTimestampNumber(messageEvent.timestamp),
     messageEvent: {
       // tslint:disable-next-line:ban Needed to parse hexadecimal.
-      id: String(parseInt(messageEvent.id, 16)),
+      id: messageEvent.id,
       type: messageEvent.type, // Enum values match proto values
       uncompressedSize: messageEvent.uncompressedSize,
       compressedSize: messageEvent.compressedSize,

--- a/packages/opencensus-web-exporter-ocagent/src/api-types.ts
+++ b/packages/opencensus-web-exporter-ocagent/src/api-types.ts
@@ -450,7 +450,7 @@ export interface MessageEvent {
    * sequence ID for a streaming RPC. It is recommended to be unique within a
    * Span.
    */
-  id?: string;
+  id?: string | number;
   /**
    * The number of uncompressed bytes sent or received.
    */

--- a/packages/opencensus-web-exporter-ocagent/test/test-adapters.ts
+++ b/packages/opencensus-web-exporter-ocagent/test/test-adapters.ts
@@ -137,7 +137,7 @@ describe('Core to API Span adapters', () => {
     webSpan1.endPerfTime = 20.113;
     webSpan1.messageEvents = [
       {
-        id: '1',
+        id: 1,
         timestamp: 19.002,
         type: webCore.MessageEventType.SENT,
         uncompressedSize: 22,
@@ -209,7 +209,7 @@ describe('Core to API Span adapters', () => {
             {
               time: '2019-01-20T16:00:00.019002000Z',
               messageEvent: {
-                id: '1',
+                id: 1,
                 type: API_MESSAGE_EVENT_TYPE_SENT,
                 uncompressedSize: 22,
                 compressedSize: 15,

--- a/packages/opencensus-web-types/package.json
+++ b/packages/opencensus-web-types/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "npm run compile",
     "clean": "rimraf build/*",
-    "copytypes": "node scripts/copy-types.js '27de0b1e3422df31af936a0dba457728ff4bffc2' && npm run fix",
+    "copytypes": "node scripts/copy-types.js 'v0.0.11' && npm run fix",
     "check": "gts check",
     "compile": "tsc -p .",
     "fix": "gts fix",

--- a/packages/opencensus-web-types/src/trace/model/types.ts
+++ b/packages/opencensus-web-types/src/trace/model/types.ts
@@ -192,13 +192,12 @@ export interface MessageEvent {
   /** Indicates whether the message was sent or received. */
   type: MessageEventType;
   /**
-   * An identifier for the MessageEvent's message. This should be a hexadecimal
-   * value that fits within 64-bits. Message event ids should start with 1 for
+   * An identifier for the MessageEvent's message that can be used to match
+   * SENT and RECEIVED MessageEvents. Message event ids should start with 1 for
    * both sent and received messages and increment by 1 for each message
-   * sent/received. See:
-   * https://github.com/census-instrumentation/opencensus-specs/blob/master/trace/gRPC.md#message-events
+   * sent/received.
    */
-  id: string;
+  id: number;
   /** The number of uncompressed bytes sent or received. */
   uncompressedSize?: number;
   /**
@@ -441,7 +440,7 @@ export interface Span {
    */
   addMessageEvent(
     type: MessageEventType,
-    id: string,
+    id: number,
     timestamp?: number,
     uncompressedSize?: number,
     compressedSize?: number


### PR DESCRIPTION
This adds a little breaking change on ``addMessageEvent()`, the field `id` is now a number instead of string.