### PR TITLE
Update types to commit 92edaa9

### DIFF
--- a/packages/opencensus-web-core/src/trace/model/root-span.ts
+++ b/packages/opencensus-web-core/src/trace/model/root-span.ts
@@ -22,7 +22,7 @@ import { Span } from './span';
 export class RootSpan extends Span {
   constructor(
     /** Trace associated with this root span. */
-    private readonly tracer: webTypes.Tracer,
+    private readonly tracer: webTypes.TracerBase,
     /** A trace options object to build the root span. */
     context?: webTypes.TraceOptions
   ) {

--- a/packages/opencensus-web-core/src/trace/model/tracer-base.ts
+++ b/packages/opencensus-web-core/src/trace/model/tracer-base.ts
@@ -1,0 +1,120 @@
+/**
+ * Copyright 2019, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as webTypes from '@opencensus/web-types';
+import { NoHeadersPropagation } from '../propagation/no_headers_propagation';
+import { AlwaysSampler } from '../sampler/sampler';
+import { RootSpan } from './root-span';
+import { Span } from './span';
+
+const NO_HEADERS_PROPAGATION = new NoHeadersPropagation();
+
+/** Tracer manages the current root span and trace header propagation. */
+export class TracerBase implements webTypes.TracerBase {
+  /**
+   * A sampler used to make trace sample decisions. In the case of
+   * opencensus-web, ultimate sampling decisions will likely be made by the
+   * server or agent/collector. So this defaults to sampling every trace.
+   */
+  sampler = new AlwaysSampler();
+
+  /** An object to log information to. Logs to the JS console by default. */
+  logger: webTypes.Logger = console;
+
+  /** Trace context header propagation behavior. */
+  propagation = NO_HEADERS_PROPAGATION;
+
+  /** Event listeners for spans managed by the tracer. */
+  eventListeners: webTypes.SpanEventListener[] = [];
+
+  /**
+   * Active status from tracer instance - this is always true for
+   * opencensus-web for code simplicity purposes.
+   */
+  active = true;
+
+  /**
+   * Trace parameter configuration. Not used by OpenCensus Web, but
+   * kept for interface compatibility with @opencensus/web-types.
+   */
+  readonly activeTraceParams = {};
+
+  /**
+   * Starts the tracer. This makes the tracer active and sets `logger` and
+   * `propagation` based on the given config. The `samplingRate` property of
+   * `config` is currently ignored.
+   */
+  start(config: webTypes.TracerConfig): this {
+    this.logger = config.logger || console;
+    this.propagation = config.propagation || NO_HEADERS_PROPAGATION;
+    return this;
+  }
+
+  /** Stops the tracer. This is a no-op with opencensus-web. */
+  stop(): this {
+    return this;
+  }
+
+  /**
+   * Start a new RootSpan to currentRootSpan. Currently opencensus-web only
+   * supports a single root span at a time, so this just sets `currentRootSpan`
+   * to a new root span based on the given options and invokes the passed
+   * function. Currently no sampling decisions are propagated or made here.
+   * @param options Options for tracer instance
+   * @param fn Callback function
+   * @returns The callback return
+   */
+  startRootSpan<T>(options: webTypes.TraceOptions, fn: (root: Span) => T): T {
+    const rootSpan = new RootSpan(this, options);
+    rootSpan.start();
+    return fn(rootSpan);
+  }
+
+  /** Notifies listeners of the span start. */
+  onStartSpan(root: webTypes.Span) {
+    for (const listener of this.eventListeners) {
+      listener.onStartSpan(root);
+    }
+  }
+
+  /** Notifies listeners of the span end. */
+  onEndSpan(root: webTypes.Span) {
+    for (const listener of this.eventListeners) {
+      listener.onEndSpan(root);
+    }
+  }
+
+  registerSpanEventListener(listener: webTypes.SpanEventListener) {
+    this.eventListeners.push(listener);
+  }
+
+  unregisterSpanEventListener(listener: webTypes.SpanEventListener) {
+    this.eventListeners = this.eventListeners.filter(l => l !== listener);
+  }
+
+  /**
+   * Start a new Span.
+   * @param name SpanOptions object.
+   * @returns The new Span instance started
+   */
+  startChildSpan(options?: webTypes.SpanOptions): Span {
+    let span = new Span();
+    if (options && options.childOf) {
+      span = options.childOf as Span;
+    }
+    return span.startChildSpan(options);
+  }
+}

--- a/packages/opencensus-web-core/src/trace/model/tracer-base.ts
+++ b/packages/opencensus-web-core/src/trace/model/tracer-base.ts
@@ -22,7 +22,7 @@ import { Span } from './span';
 
 const NO_HEADERS_PROPAGATION = new NoHeadersPropagation();
 
-/** Tracer manages the current root span and trace header propagation. */
+/** TracerBase represents a tracer */
 export class TracerBase implements webTypes.TracerBase {
   /**
    * A sampler used to make trace sample decisions. In the case of
@@ -69,10 +69,7 @@ export class TracerBase implements webTypes.TracerBase {
   }
 
   /**
-   * Start a new RootSpan to currentRootSpan. Currently opencensus-web only
-   * supports a single root span at a time, so this just sets `currentRootSpan`
-   * to a new root span based on the given options and invokes the passed
-   * function. Currently no sampling decisions are propagated or made here.
+   * Start a new RootSpan to currentRootSpan. Currently no sampling decisions are propagated or made here.
    * @param options Options for tracer instance
    * @param fn Callback function
    * @returns The callback return

--- a/packages/opencensus-web-core/test/index.ts
+++ b/packages/opencensus-web-core/test/index.ts
@@ -25,3 +25,4 @@ import './test-trace-model-util';
 import './test-tracer';
 import './test-tracing';
 import './test-url-util';
+import './test-tracer-base';

--- a/packages/opencensus-web-core/test/test-tracer-base.ts
+++ b/packages/opencensus-web-core/test/test-tracer-base.ts
@@ -1,0 +1,88 @@
+/**
+ * Copyright 2019, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as webTypes from '@opencensus/web-types';
+import { RootSpan } from '../src/trace/model/root-span';
+import { TracerBase } from '../src/trace/model/tracer-base';
+
+describe('TracerBase', () => {
+  let tracer: TracerBase;
+  let listener: webTypes.SpanEventListener;
+
+  beforeEach(() => {
+    tracer = new TracerBase();
+    listener = jasmine.createSpyObj<webTypes.SpanEventListener>('listener', [
+      'onStartSpan',
+      'onEndSpan',
+    ]);
+    tracer.eventListeners = [listener];
+  });
+
+  describe('start', () => {
+    it('sets logger and propagation based on config', () => {
+      const mockLogger = jasmine.createSpyObj<webTypes.Logger>('logger', [
+        'info',
+      ]);
+      const mockPropagation = jasmine.createSpyObj<webTypes.Propagation>(
+        'propagation',
+        ['generate']
+      );
+
+      const result = tracer.start({
+        logger: mockLogger,
+        propagation: mockPropagation,
+      });
+
+      expect(result).toBe(tracer);
+      expect(tracer.logger).toBe(mockLogger);
+      expect(tracer.propagation).toBe(mockPropagation);
+    });
+  });
+
+  describe('onStartSpan', () => {
+    it('notifies span listeners', () => {
+      const newRoot = new RootSpan(tracer);
+      tracer.onStartSpan(newRoot);
+      expect(listener.onStartSpan).toHaveBeenCalledWith(newRoot);
+    });
+  });
+
+  describe('onEndSpan', () => {
+    it('notifies span listeners', () => {
+      const newRoot = new RootSpan(tracer);
+      tracer.onEndSpan(newRoot);
+      expect(listener.onEndSpan).toHaveBeenCalledWith(newRoot);
+    });
+  });
+
+  describe('registerSpanEventListener', () => {
+    it('adds to listeners', () => {
+      const newListener = jasmine.createSpyObj<webTypes.SpanEventListener>(
+        'newListener',
+        ['onStartSpan', 'onEndSpan']
+      );
+      tracer.registerSpanEventListener(newListener);
+      expect(tracer.eventListeners).toEqual([listener, newListener]);
+    });
+  });
+
+  describe('unregisterSpanEventListener', () => {
+    it('removes from listeners', () => {
+      tracer.unregisterSpanEventListener(listener);
+      expect(tracer.eventListeners).toEqual([]);
+    });
+  });
+});

--- a/packages/opencensus-web-types/package.json
+++ b/packages/opencensus-web-types/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "npm run compile",
     "clean": "rimraf build/*",
-    "copytypes": "node scripts/copy-types.js 'abd41dbc0f2f5836980ae9d79048a81d58a9956f' && npm run fix",
+    "copytypes": "node scripts/copy-types.js '92edaa9d406ac74e1805a4e80b756acedc413001' && npm run fix",
     "check": "gts check",
     "compile": "tsc -p .",
     "fix": "gts fix",

--- a/packages/opencensus-web-types/src/trace/instrumentation/types.ts
+++ b/packages/opencensus-web-types/src/trace/instrumentation/types.ts
@@ -15,7 +15,7 @@
  */
 
 import { Stats } from '../../stats/types';
-import { Tracer } from '../model/types';
+import { TracerBase } from '../model/types';
 
 /** Interface Plugin to apply patch. */
 export interface Plugin {
@@ -31,7 +31,7 @@ export interface Plugin {
    */
   enable<T>(
     moduleExports: T,
-    tracer: Tracer,
+    tracer: TracerBase,
     version: string,
     options: PluginConfig,
     basedir?: string,

--- a/packages/opencensus-web-types/src/trace/model/types.ts
+++ b/packages/opencensus-web-types/src/trace/model/types.ts
@@ -474,11 +474,8 @@ export interface Span {
   startChildSpan(nameOrOptions?: string | SpanOptions, kind?: SpanKind): Span;
 }
 
-/** Interface for Tracer */
-export interface Tracer extends SpanEventListener {
-  /** Get and set the currentRootSpan to tracer instance */
-  currentRootSpan: Span;
-
+/** Interface for TracerBase */
+export interface TracerBase extends SpanEventListener {
   /** A sampler that will decide if the span will be sampled or not */
   sampler: samplerTypes.Sampler;
 
@@ -502,10 +499,10 @@ export interface Tracer extends SpanEventListener {
    * @param config Configuration for tracer instace
    * @returns A tracer instance started
    */
-  start(config: configTypes.TracerConfig): Tracer;
+  start(config: configTypes.TracerConfig): this;
 
   /** Stop the tracer instance */
-  stop(): Tracer;
+  stop(): this;
 
   /**
    * Start a new RootSpan to currentRootSpan
@@ -527,18 +524,22 @@ export interface Tracer extends SpanEventListener {
    */
   unregisterSpanEventListener(listener: SpanEventListener): void;
 
-  /** Clear the currentRootSpan from tracer instance */
-  clearCurrentTrace(): void;
-
   /**
    * Start a new Span instance to the currentRootSpan
-   * @param name Span name
-   * @param kind Span kind
-   * @param options Span Options
+   * @param childOf Span
+   * @param [options] A TraceOptions object to start a root span.
    * @returns The new Span instance started
    */
-  startChildSpan(name?: string, kind?: SpanKind): Span;
   startChildSpan(options?: SpanOptions): Span;
+}
+
+/** Interface for Tracer */
+export interface Tracer extends TracerBase {
+  /** Get and set the currentRootSpan to tracer instance */
+  currentRootSpan: Span;
+
+  /** Clear the currentRootSpan from tracer instance */
+  clearCurrentTrace(): void;
 
   /**
    * Binds the trace context to the given function.

--- a/packages/opencensus-web-types/src/trace/types.ts
+++ b/packages/opencensus-web-types/src/trace/types.ts
@@ -21,7 +21,7 @@ import * as modelTypes from './model/types';
 /** Main interface for tracing. */
 export interface Tracing {
   /** Object responsible for managing a trace. */
-  readonly tracer: modelTypes.Tracer;
+  readonly tracer: modelTypes.TracerBase;
 
   /** Service to send collected traces to. */
   readonly exporter: exportersTypes.Exporter;


### PR DESCRIPTION
Update Tracer types to commit [92edaa9](https://github.com/census-instrumentation/opencensus-node/commit/92edaa9d406ac74e1805a4e80b756acedc413001#diff-3f8af03ea7f8295217dd1ec432ceda36)

Changes:
- startChildSpan now only accepts option object.
- Add new TracerBase type.
