### PR TITLE
Intercept multiple events triggered by the same DOM element and create only one Zone.

### DIFF
--- a/packages/opencensus-web-instrumentation-zone/src/interaction-tracker.ts
+++ b/packages/opencensus-web-instrumentation-zone/src/interaction-tracker.ts
@@ -37,7 +37,7 @@ const RESET_TRACING_ZONE_DELAY = 50;
 
 export class InteractionTracker {
   // Allows to track several events triggered by the same user interaction in the right Zone.
-  private currentEventTracingZone?: Zone = undefined;
+  private currentEventTracingZone?: Zone;
 
   constructor() {
     const runTask = Zone.prototype.runTask;
@@ -52,12 +52,11 @@ export class InteractionTracker {
       console.log(task);
       console.log(task.zone);
 
-      let taskZone: Zone = Zone.current;
+      let taskZone = Zone.current;
       if (isTrackedElement(task)) {
         console.log('Click detected');
 
         if (this.currentEventTracingZone === undefined) {          
-
           const traceId = randomTraceId();
           this.currentEventTracingZone = Zone.root.fork({
             name: traceId,

--- a/packages/opencensus-web-instrumentation-zone/src/interaction-tracker.ts
+++ b/packages/opencensus-web-instrumentation-zone/src/interaction-tracker.ts
@@ -32,63 +32,60 @@ export type AsyncTask = Task & {
   _zone: Zone;
 };
 
+// Delay of 50 ms to reset currentEventTracingZone.
+const RESET_TRACING_ZONE_DELAY = 50;
+
 export class InteractionTracker {
   // Allows to track several events triggered by the same user interaction in the right Zone.
   private currentEventTracingZone?: Zone = undefined;
 
-  // Delay of 50 ms to reset currentEventTracingZone.
-  private readonly RESET_TRACING_ZONE_DELAY: number = 50;
-
   constructor() {
-    // Keep track of interaction tracker for monkey-patched methods.
-    const interactionTracker: InteractionTracker = this;
-
     const runTask = Zone.prototype.runTask;
-    Zone.prototype.runTask = function(
+    Zone.prototype.runTask = (
       task: AsyncTask,
       applyThis: unknown,
       applyArgs: unknown
-    ) {
+    ) => {
       const time = Date.now();
 
       console.warn('Running task');
       console.log(task);
       console.log(task.zone);
 
-      let taskZone = this;
+      let taskZone: Zone = Zone.current;
       if (isTrackedElement(task)) {
         console.log('Click detected');
 
-        if (interactionTracker.currentEventTracingZone === undefined) {
-          // Timeout to reset currentEventTracingZone to allow the creation of a new
-          // zone for a new user interaction.
-          Zone.root.run(() =>
-            setTimeout(
-              () => (interactionTracker.currentEventTracingZone = undefined),
-              interactionTracker.RESET_TRACING_ZONE_DELAY
-            )
-          );
+        if (this.currentEventTracingZone === undefined) {          
 
           const traceId = randomTraceId();
-          interactionTracker.currentEventTracingZone = Zone.root.fork({
+          this.currentEventTracingZone = Zone.root.fork({
             name: traceId,
             properties: {
               isTracingZone: true,
               traceId,
             },
           });
+
+          // Timeout to reset currentEventTracingZone to allow the creation of a new
+          // zone for a new user interaction.
+          Zone.root.run(() =>
+            setTimeout(
+              () => (this.currentEventTracingZone = undefined),
+              RESET_TRACING_ZONE_DELAY
+            )
+          );
+
           console.log('New zone:');
-          console.log(interactionTracker.currentEventTracingZone);
+          console.log(this.currentEventTracingZone);
         }
 
         // Change the zone task.
-        task._zone = interactionTracker.currentEventTracingZone;
-        taskZone = interactionTracker.currentEventTracingZone;
-      } else {
+        task._zone = this.currentEventTracingZone;
+        taskZone = this.currentEventTracingZone;
+      } else if (task.zone && task.zone.get('isTracingZone')) {
         // If we already are in a tracing zone, just run the task in our tracing zone.
-        if (task.zone && task.zone.get('isTracingZone')) {
-          taskZone = task.zone;
-        }
+        taskZone = task.zone;
       }
       try {
         return runTask.call(taskZone as {}, task, applyThis, applyArgs);


### PR DESCRIPTION
When a button is clicked it may trigger click event from the _button_ and the _document_ but in the end both events correspond to the same user interaction and they must be tracked in the same Zone. This PR fixes this.