### PR TITLE
Custom end time for span

### DIFF
--- a/packages/opencensus-web-core/src/trace/model/span.ts
+++ b/packages/opencensus-web-core/src/trace/model/span.ts
@@ -261,7 +261,9 @@ export class Span implements webTypes.Span {
 
   /** Ends the span by setting `endTime` to now. */
   end() {
-    this.endPerfTime = performance.now();
+    if (this.endPerfTime === 0) {
+      this.endPerfTime = performance.now();
+    }
   }
 
   /** Forces the span to end. Same as `end` for opencensus-web. */

--- a/packages/opencensus-web-core/test/test-span.ts
+++ b/packages/opencensus-web-core/test/test-span.ts
@@ -95,6 +95,12 @@ describe('Span', () => {
     expect(span.endPerfTime).toBe(33);
   });
 
+  it('does not set endPerfTime when end is called, if endPerfTime is already set', () => {
+    span.endPerfTime = 22;
+    span.end();
+    expect(span.endPerfTime).toBe(22);
+  });
+
   it('sets endPerfTime when truncate is called', () => {
     spyOn(performance, 'now').and.returnValue(77);
     span.truncate();


### PR DESCRIPTION
Setting endPerfTime `span.end` only when the endPerfTime is 0 (default). A custom end time on span can now be set by doing `span.endPerfTime = <custom-end-time>`. 

`span.end` will not overwrite the custom endPerfTime now

Issue https://github.com/census-instrumentation/opencensus-web/issues/70