### PR TITLE
Send user interaction trace

### DIFF
--- a/examples/user_interaction/client/src/App.js
+++ b/examples/user_interaction/client/src/App.js
@@ -97,7 +97,7 @@ class App extends React.Component {
         and calculate the amount of prime numbers in between 1 and 100000. These
         calculations are done using slow methods in order to measure the traces.</p>
 
-        <button onClick={this.handleClick}>Trace user interaction</button>
+        <button id='trace_interaction' data-ocweb-id='Trace user interaction' onClick={this.handleClick}>Trace user interaction</button>
 
         <p>The value of Pi is: <code>{this.state.pi.value}</code> and it took
         <code> {this.state.pi.time} ms </code> to compute this.</p>

--- a/packages/opencensus-web-all/package-lock.json
+++ b/packages/opencensus-web-all/package-lock.json
@@ -158,43 +158,6 @@
         }
       }
     },
-    "@opencensus/web-core": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@opencensus/web-core/-/web-core-0.0.2.tgz",
-      "integrity": "sha512-X4TK3ZUieG9mDHeAfQd6RpEukAIAVqhbNx6Ar4v1YQGqsia0yLeBxoFzOBZ9dJbuY6ULvQt4tm5EbrPlc9eJKQ==",
-      "requires": {
-        "@opencensus/web-types": "^0.0.2"
-      }
-    },
-    "@opencensus/web-exporter-ocagent": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@opencensus/web-exporter-ocagent/-/web-exporter-ocagent-0.0.2.tgz",
-      "integrity": "sha512-NWHiquSwU0e+b0JPBhbpb5aeVv4Q9vYs71NmFmYZw2cWPFO0Z/SsFMactNQHSTujllIikNmRqNaGKn9xHO8ZGA==",
-      "requires": {
-        "@opencensus/web-core": "^0.0.2"
-      }
-    },
-    "@opencensus/web-instrumentation-perf": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@opencensus/web-instrumentation-perf/-/web-instrumentation-perf-0.0.2.tgz",
-      "integrity": "sha512-PUqpnAO39IoTXbeslf1DuZOEBCrI/N0ekcmk0lHOmgxzKZkXwrRbyQV0D5uPaAvSbzj7CuSAGiFseH0COR8GSw==",
-      "requires": {
-        "@opencensus/web-core": "^0.0.2"
-      }
-    },
-    "@opencensus/web-propagation-tracecontext": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@opencensus/web-propagation-tracecontext/-/web-propagation-tracecontext-0.0.2.tgz",
-      "integrity": "sha512-EArpCj8pyEhu9tATW4pVIRQ8/fJ8KeyKigzklzTCaTeTTImngExhNjGsrVLOW0XcXHQg2oTrPVBcsv/qA8PLgg==",
-      "requires": {
-        "@opencensus/web-core": "^0.0.2"
-      }
-    },
-    "@opencensus/web-types": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@opencensus/web-types/-/web-types-0.0.2.tgz",
-      "integrity": "sha512-SAXdV8nWJq7pgk4LM7r6R1fSoxCnkRHOfmPLkncK6M4zaTRwi8t3UPQlSoVBUxp/bJBFsZXivBVWntx0MPZjKQ=="
-    },
     "@types/jasmine": {
       "version": "3.3.5",
       "resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-3.3.5.tgz",

--- a/packages/opencensus-web-all/package-lock.json
+++ b/packages/opencensus-web-all/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencensus/web-all",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -157,6 +157,43 @@
           "dev": true
         }
       }
+    },
+    "@opencensus/web-core": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@opencensus/web-core/-/web-core-0.0.3.tgz",
+      "integrity": "sha512-NNzPEokepUcaybOg7d67Wu2fIpKQIwaNHA1w09Dur5Fg233/VlojGg/iqPpgz9TO9xS9+o/nz6XZPSylB9kq4A==",
+      "requires": {
+        "@opencensus/web-types": "^0.0.3"
+      }
+    },
+    "@opencensus/web-exporter-ocagent": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@opencensus/web-exporter-ocagent/-/web-exporter-ocagent-0.0.3.tgz",
+      "integrity": "sha512-YXrNvbNi/FijWoFL1I2dHoC/luMiXHpUUML31DNpjRPMD4OkqFf81v3IR40QYjSKSCDfja6MSFAC5hvPgrjoMg==",
+      "requires": {
+        "@opencensus/web-core": "^0.0.3"
+      }
+    },
+    "@opencensus/web-instrumentation-perf": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@opencensus/web-instrumentation-perf/-/web-instrumentation-perf-0.0.3.tgz",
+      "integrity": "sha512-C76EEpzd38rHNOhMO0jiZBJhbdd1fdwe6rYq9C7qpDzLbQl90JAgyBWOv0BsfWbn7FX71rlV3dlKCnhlHAN7sw==",
+      "requires": {
+        "@opencensus/web-core": "^0.0.3"
+      }
+    },
+    "@opencensus/web-propagation-tracecontext": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@opencensus/web-propagation-tracecontext/-/web-propagation-tracecontext-0.0.3.tgz",
+      "integrity": "sha512-YXOi38GscRLIorFFhLl7ZQqcO8bzDVCo7qdbeExKI+hzyuC3RygswqQt7P9j23tnfoRBPTHxKwbJAY3JZYBcbw==",
+      "requires": {
+        "@opencensus/web-core": "^0.0.3"
+      }
+    },
+    "@opencensus/web-types": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@opencensus/web-types/-/web-types-0.0.3.tgz",
+      "integrity": "sha512-bEjL1AQErMR5CIGM28sd2fjrfsNGYXatYqoEcS8kqPgxcl6TPZSA4o5cqGBsTnC6QALZh3CMzmjod8vIR/TcYw=="
     },
     "@types/jasmine": {
       "version": "3.3.5",

--- a/packages/opencensus-web-core/karma.conf.js
+++ b/packages/opencensus-web-core/karma.conf.js
@@ -26,7 +26,7 @@ module.exports = (config) => {
     browsers: ['ChromeHeadless'],
     frameworks: ['jasmine'],
     reporters: ['spec', 'coverage-istanbul'],
-    files: ['test/index.ts'],
+    files: ['test/index.ts', 'node_modules/zone.js/dist/zone.js'],
     preprocessors: {'test/index.ts': ['webpack']},
     // Use webpack so that tree-shaking will remove all Node.js dependencies of
     // the `@opencensus/web-types` library, since they are not actually used in this

--- a/packages/opencensus-web-core/package-lock.json
+++ b/packages/opencensus-web-core/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencensus/web-core",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -6871,6 +6871,12 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz",
       "integrity": "sha1-AI4G2AlDIMNy28L47XagymyKxBk=",
+      "dev": true
+    },
+    "zone.js": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.9.1.tgz",
+      "integrity": "sha512-GkPiJL8jifSrKReKaTZ5jkhrMEgXbXYC+IPo1iquBjayRa0q86w3Dipjn8b415jpitMExe9lV8iTsv8tk3DGag==",
       "dev": true
     }
   }

--- a/packages/opencensus-web-core/package.json
+++ b/packages/opencensus-web-core/package.json
@@ -59,7 +59,8 @@
     "ts-loader": "^6.0.0",
     "typescript": "^3.1.6",
     "webpack": "^4.18.0",
-    "webpack-cli": "^3.1.0"
+    "webpack-cli": "^3.1.0",
+    "zone.js": "^0.9.1"
   },
   "dependencies": {
     "@opencensus/web-types": "^0.0.3"

--- a/packages/opencensus-web-core/src/index.ts
+++ b/packages/opencensus-web-core/src/index.ts
@@ -54,5 +54,5 @@ export * from './common/id-util';
 
 // Export global tracing instance.
 import { Tracing } from './trace/model/tracing';
-const tracing = new Tracing();
+const tracing = Tracing.instance;
 export { tracing };

--- a/packages/opencensus-web-core/src/trace/model/tracer-base.ts
+++ b/packages/opencensus-web-core/src/trace/model/tracer-base.ts
@@ -136,6 +136,6 @@ export class TracerBase implements webTypes.TracerBase {
 
   /** Sets the current root span. */
   setCurrentRootSpan(root: webTypes.Span) {
-    // no-op, this is only required in case of tracer with cls.
+    // no-op, this is only required in case of tracer with Zones.
   }
 }

--- a/packages/opencensus-web-core/src/trace/model/tracing.ts
+++ b/packages/opencensus-web-core/src/trace/model/tracing.ts
@@ -31,6 +31,14 @@ export class Tracing implements webTypes.Tracing {
   /** Whether tracing is active - always true for opencensus-web. */
   active = true;
 
+  /** Singleton instance */
+  private static singletonInstance: Tracing;
+
+  /** Gets the tracing instance. */
+  static get instance(): Tracing {
+    return this.singletonInstance || (this.singletonInstance = new this());
+  }
+
   /** Sets tracer and exporter config. */
   start(config?: webTypes.Config): webTypes.Tracing {
     this.tracer.start(config || {});

--- a/packages/opencensus-web-core/tsconfig.json
+++ b/packages/opencensus-web-core/tsconfig.json
@@ -17,6 +17,5 @@
       "test/*": ["./test/*"]
     }
   },
-  "exclude": ["node_modules"],
-  "include": ["src/**/*.ts", "test/**/*.ts"]
+  "include": ["src/**/*.ts", "test/**/*.ts", "node_modules/zone.js/dist/zone.js.d.ts"]
 }

--- a/packages/opencensus-web-exporter-ocagent/package-lock.json
+++ b/packages/opencensus-web-exporter-ocagent/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencensus/web-exporter-ocagent",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -157,6 +157,19 @@
           "dev": true
         }
       }
+    },
+    "@opencensus/web-core": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@opencensus/web-core/-/web-core-0.0.3.tgz",
+      "integrity": "sha512-NNzPEokepUcaybOg7d67Wu2fIpKQIwaNHA1w09Dur5Fg233/VlojGg/iqPpgz9TO9xS9+o/nz6XZPSylB9kq4A==",
+      "requires": {
+        "@opencensus/web-types": "^0.0.3"
+      }
+    },
+    "@opencensus/web-types": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@opencensus/web-types/-/web-types-0.0.3.tgz",
+      "integrity": "sha512-bEjL1AQErMR5CIGM28sd2fjrfsNGYXatYqoEcS8kqPgxcl6TPZSA4o5cqGBsTnC6QALZh3CMzmjod8vIR/TcYw=="
     },
     "@types/jasmine": {
       "version": "3.3.5",

--- a/packages/opencensus-web-instrumentation-perf/package-lock.json
+++ b/packages/opencensus-web-instrumentation-perf/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencensus/web-instrumentation-perf",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -159,17 +159,17 @@
       }
     },
     "@opencensus/web-core": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@opencensus/web-core/-/web-core-0.0.2.tgz",
-      "integrity": "sha512-X4TK3ZUieG9mDHeAfQd6RpEukAIAVqhbNx6Ar4v1YQGqsia0yLeBxoFzOBZ9dJbuY6ULvQt4tm5EbrPlc9eJKQ==",
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@opencensus/web-core/-/web-core-0.0.3.tgz",
+      "integrity": "sha512-NNzPEokepUcaybOg7d67Wu2fIpKQIwaNHA1w09Dur5Fg233/VlojGg/iqPpgz9TO9xS9+o/nz6XZPSylB9kq4A==",
       "requires": {
-        "@opencensus/web-types": "^0.0.2"
+        "@opencensus/web-types": "^0.0.3"
       }
     },
     "@opencensus/web-types": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@opencensus/web-types/-/web-types-0.0.2.tgz",
-      "integrity": "sha512-SAXdV8nWJq7pgk4LM7r6R1fSoxCnkRHOfmPLkncK6M4zaTRwi8t3UPQlSoVBUxp/bJBFsZXivBVWntx0MPZjKQ=="
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@opencensus/web-types/-/web-types-0.0.3.tgz",
+      "integrity": "sha512-bEjL1AQErMR5CIGM28sd2fjrfsNGYXatYqoEcS8kqPgxcl6TPZSA4o5cqGBsTnC6QALZh3CMzmjod8vIR/TcYw=="
     },
     "@types/jasmine": {
       "version": "3.3.5",

--- a/packages/opencensus-web-instrumentation-zone/package-lock.json
+++ b/packages/opencensus-web-instrumentation-zone/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencensus/web-instrumentation-zone",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -159,17 +159,25 @@
       }
     },
     "@opencensus/web-core": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@opencensus/web-core/-/web-core-0.0.2.tgz",
-      "integrity": "sha512-X4TK3ZUieG9mDHeAfQd6RpEukAIAVqhbNx6Ar4v1YQGqsia0yLeBxoFzOBZ9dJbuY6ULvQt4tm5EbrPlc9eJKQ==",
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@opencensus/web-core/-/web-core-0.0.3.tgz",
+      "integrity": "sha512-NNzPEokepUcaybOg7d67Wu2fIpKQIwaNHA1w09Dur5Fg233/VlojGg/iqPpgz9TO9xS9+o/nz6XZPSylB9kq4A==",
       "requires": {
-        "@opencensus/web-types": "^0.0.2"
+        "@opencensus/web-types": "^0.0.3"
+      }
+    },
+    "@opencensus/web-exporter-ocagent": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@opencensus/web-exporter-ocagent/-/web-exporter-ocagent-0.0.3.tgz",
+      "integrity": "sha512-YXrNvbNi/FijWoFL1I2dHoC/luMiXHpUUML31DNpjRPMD4OkqFf81v3IR40QYjSKSCDfja6MSFAC5hvPgrjoMg==",
+      "requires": {
+        "@opencensus/web-core": "^0.0.3"
       }
     },
     "@opencensus/web-types": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@opencensus/web-types/-/web-types-0.0.2.tgz",
-      "integrity": "sha512-SAXdV8nWJq7pgk4LM7r6R1fSoxCnkRHOfmPLkncK6M4zaTRwi8t3UPQlSoVBUxp/bJBFsZXivBVWntx0MPZjKQ=="
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@opencensus/web-types/-/web-types-0.0.3.tgz",
+      "integrity": "sha512-bEjL1AQErMR5CIGM28sd2fjrfsNGYXatYqoEcS8kqPgxcl6TPZSA4o5cqGBsTnC6QALZh3CMzmjod8vIR/TcYw=="
     },
     "@types/events": {
       "version": "3.0.0",

--- a/packages/opencensus-web-instrumentation-zone/package.json
+++ b/packages/opencensus-web-instrumentation-zone/package.json
@@ -65,7 +65,8 @@
     "zone.js": "~0.9.1"
   },
   "dependencies": {
-    "@opencensus/web-core": "^0.0.2"
+    "@opencensus/web-core": "^0.0.2",
+    "@opencensus/web-exporter-ocagent": "^0.0.2"
   },
   "peerDependencies": {
     "zone.js": "~0.9.1"

--- a/packages/opencensus-web-instrumentation-zone/src/export-initial-load.ts
+++ b/packages/opencensus-web-instrumentation-zone/src/export-initial-load.ts
@@ -14,8 +14,31 @@
  * limitations under the License.
  */
 
+import { tracing } from '@opencensus/web-core';
+import { OCAgentExporter } from '@opencensus/web-exporter-ocagent';
+import { WindowWithOcwGlobals } from './zone-types';
+
+const windowWithOcwGlobals = window as WindowWithOcwGlobals;
+
+/** Trace endpoint in the OC agent. */
+const TRACE_ENDPOINT = '/v1/trace';
+
 import { InteractionTracker } from './interaction-tracker';
 
+function setupExporter() {
+  if (!windowWithOcwGlobals.ocAgent) {
+    console.log('Not configured to export page load spans.');
+    return;
+  }
+
+  tracing.registerExporter(
+    new OCAgentExporter({
+      agentEndpoint: `${windowWithOcwGlobals.ocAgent}${TRACE_ENDPOINT}`,
+    })
+  );
+}
+
 export function startInteractionTracker() {
+  setupExporter();
   return new InteractionTracker();
 }

--- a/packages/opencensus-web-instrumentation-zone/src/on-page-interaction.ts
+++ b/packages/opencensus-web-instrumentation-zone/src/on-page-interaction.ts
@@ -15,12 +15,14 @@
  */
 
 import { OnPageInteractionData } from './zone-types';
+import {
+  ATTRIBUTE_HTTP_URL,
+  ATTRIBUTE_HTTP_USER_AGENT,
+} from '@opencensus/web-core';
 
 /** A helper class for tracking on page interactions. */
 export class OnPageInteractionStopwatch {
   private taskCount = 0;
-  private readonly startTimeMs = performance.now();
-  private endTimeMs?: number;
 
   constructor(private readonly data: OnPageInteractionData) {}
 
@@ -42,11 +44,14 @@ export class OnPageInteractionStopwatch {
 
   /** Stops the stopwatch and record the xhr response. */
   stopAndRecord(): void {
-    this.endTimeMs = performance.now();
-    const latencyMs = this.endTimeMs - this.startTimeMs;
+    const rootSpan = this.data.rootSpan;
+    rootSpan.addAttribute('EventType', this.data.eventType);
+    rootSpan.addAttribute('TargetElement', this.data.target.tagName);
+    rootSpan.addAttribute(ATTRIBUTE_HTTP_URL, location.href);
+    rootSpan.addAttribute(ATTRIBUTE_HTTP_USER_AGENT, navigator.userAgent);
+    rootSpan.end();
     console.log('End of tracking. The interaction is stable.');
-    console.log('Time to stable: ' + latencyMs + ' ms.');
-    console.log(this.data);
+    console.log('Time to stable: ' + this.data.rootSpan.duration + ' ms.');
   }
 }
 

--- a/packages/opencensus-web-instrumentation-zone/src/zone-types.ts
+++ b/packages/opencensus-web-instrumentation-zone/src/zone-types.ts
@@ -44,23 +44,6 @@ export declare interface WindowWithOcwGlobals extends Window {
    */
   ocAgent?: string;
   /**
-   * For the initial page load, web browsers do not send any custom headers,
-   * which means that the server will not receive trace context headers.
-   * However, we still want the server side request for the initial page load to
-   * be recorded as a child span of the client side web timing span. So we can
-   * have servers programmatically set a `traceparent` header to give their
-   * request span a parent span ID. That simulated trace context header can then
-   * be sent back to the client as a global variable to use for setting its
-   * trace ID and request load client span ID, as well as for making a sampling
-   * decision.
-   * This header value is in the format of
-   *     [version]-[trace ID in hex]-[span ID in hex]-[trace flags]
-   * For example:
-   *    00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01
-   * See https://www.w3.org/TR/trace-context/ for details.
-   */
-  traceparent?: string;
-  /**
    * If the `traceparent` global variable described above is not present on the
    * `window`, then a trace sampling decision will be made randomly with the
    * specified sample rate. If not specified, a default sampling rate is used.

--- a/packages/opencensus-web-instrumentation-zone/src/zone-types.ts
+++ b/packages/opencensus-web-instrumentation-zone/src/zone-types.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import { RootSpan } from '@opencensus/web-core';
+
 export interface AsyncTaskData extends TaskData {
   interactionId: string;
   pageView: string;
@@ -29,7 +31,39 @@ export type AsyncTask = Task & {
 
 /** Data used to create a new OnPageInteractionStopwatch. */
 export interface OnPageInteractionData {
-  id: string;
   eventType: string;
   target: HTMLElement;
+  rootSpan: RootSpan;
+}
+
+/** Type for `window` object with variables OpenCensus Web interacts with. */
+export declare interface WindowWithOcwGlobals extends Window {
+  /**
+   * HTTP root URL of the agent endpoint to write traces to.
+   * Example 'https://my-oc-agent-deployment.com:55678'
+   */
+  ocAgent?: string;
+  /**
+   * For the initial page load, web browsers do not send any custom headers,
+   * which means that the server will not receive trace context headers.
+   * However, we still want the server side request for the initial page load to
+   * be recorded as a child span of the client side web timing span. So we can
+   * have servers programmatically set a `traceparent` header to give their
+   * request span a parent span ID. That simulated trace context header can then
+   * be sent back to the client as a global variable to use for setting its
+   * trace ID and request load client span ID, as well as for making a sampling
+   * decision.
+   * This header value is in the format of
+   *     [version]-[trace ID in hex]-[span ID in hex]-[trace flags]
+   * For example:
+   *    00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01
+   * See https://www.w3.org/TR/trace-context/ for details.
+   */
+  traceparent?: string;
+  /**
+   * If the `traceparent` global variable described above is not present on the
+   * `window`, then a trace sampling decision will be made randomly with the
+   * specified sample rate. If not specified, a default sampling rate is used.
+   */
+  ocSampleRate?: number;
 }

--- a/packages/opencensus-web-propagation-tracecontext/package-lock.json
+++ b/packages/opencensus-web-propagation-tracecontext/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencensus/web-propagation-tracecontext",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -159,17 +159,17 @@
       }
     },
     "@opencensus/web-core": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@opencensus/web-core/-/web-core-0.0.2.tgz",
-      "integrity": "sha512-X4TK3ZUieG9mDHeAfQd6RpEukAIAVqhbNx6Ar4v1YQGqsia0yLeBxoFzOBZ9dJbuY6ULvQt4tm5EbrPlc9eJKQ==",
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@opencensus/web-core/-/web-core-0.0.3.tgz",
+      "integrity": "sha512-NNzPEokepUcaybOg7d67Wu2fIpKQIwaNHA1w09Dur5Fg233/VlojGg/iqPpgz9TO9xS9+o/nz6XZPSylB9kq4A==",
       "requires": {
-        "@opencensus/web-types": "^0.0.2"
+        "@opencensus/web-types": "^0.0.3"
       }
     },
     "@opencensus/web-types": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@opencensus/web-types/-/web-types-0.0.2.tgz",
-      "integrity": "sha512-SAXdV8nWJq7pgk4LM7r6R1fSoxCnkRHOfmPLkncK6M4zaTRwi8t3UPQlSoVBUxp/bJBFsZXivBVWntx0MPZjKQ=="
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@opencensus/web-types/-/web-types-0.0.3.tgz",
+      "integrity": "sha512-bEjL1AQErMR5CIGM28sd2fjrfsNGYXatYqoEcS8kqPgxcl6TPZSA4o5cqGBsTnC6QALZh3CMzmjod8vIR/TcYw=="
     },
     "@types/jasmine": {
       "version": "3.3.5",

--- a/packages/opencensus-web-types/package-lock.json
+++ b/packages/opencensus-web-types/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencensus/web-types",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
This PR creates the a new RootSpan when a new user interaction is detected. This new root span will be associated to a new Zone. The root span duration represents the time to complete the user interaction.

The root span's name will be taken following some previously established rules to name the span. For this case, the example uses the `data-ocweb-id` property. 

* The span also contains some attributes like tag name of element triggering the user interaction, event that triggered it and URL.
*Changed the Tracing class as Singleton as we want only one instance of this.
*Update tracer tests.

Here an example of a new trace containing the root span.

![image](https://user-images.githubusercontent.com/22863695/59360259-cae30180-8cfd-11e9-8121-5725a00f01ce.png)

