### PR TITLE
Detect route transitions and send 'Navigation' traces.

### DIFF
--- a/examples/user_interaction/client/package-lock.json
+++ b/examples/user_interaction/client/package-lock.json
@@ -5577,6 +5577,11 @@
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE="
     },
+    "gud": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/gud/-/gud-1.0.0.tgz",
+      "integrity": "sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw=="
+    },
     "gzip-size": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-5.0.0.tgz",
@@ -5751,6 +5756,19 @@
       "resolved": "https://registry.npmjs.org/hex-color-regex/-/hex-color-regex-1.1.0.tgz",
       "integrity": "sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ=="
     },
+    "history": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/history/-/history-4.9.0.tgz",
+      "integrity": "sha512-H2DkjCjXf0Op9OAr6nJ56fcRkTSNrUiv41vNJ6IswJjif6wlpZK0BTfFbi7qK9dXLSYZxkq5lBsj3vUjlYBYZA==",
+      "requires": {
+        "@babel/runtime": "^7.1.2",
+        "loose-envify": "^1.2.0",
+        "resolve-pathname": "^2.2.0",
+        "tiny-invariant": "^1.0.2",
+        "tiny-warning": "^1.0.0",
+        "value-equal": "^0.4.0"
+      }
+    },
     "hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -5759,6 +5777,14 @@
         "hash.js": "^1.0.3",
         "minimalistic-assert": "^1.0.0",
         "minimalistic-crypto-utils": "^1.0.1"
+      }
+    },
+    "hoist-non-react-statics": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.0.tgz",
+      "integrity": "sha512-0XsbTXxgiaCDYDIWFcwkmerZPSwywfUqYmwT4jzewKTQSWoE6FCMoUVOeBJWK3E/CrWbxRG3m5GzY4lnIwGRBA==",
+      "requires": {
+        "react-is": "^16.7.0"
       }
     },
     "hosted-git-info": {
@@ -8047,6 +8073,16 @@
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
       "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
     },
+    "mini-create-react-context": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/mini-create-react-context/-/mini-create-react-context-0.3.2.tgz",
+      "integrity": "sha512-2v+OeetEyliMt5VHMXsBhABoJ0/M4RCe7fatd/fBy6SMiKazUSEt3gxxypfnk2SHMkdBYvorHRoQxuGoiwbzAw==",
+      "requires": {
+        "@babel/runtime": "^7.4.0",
+        "gud": "^1.0.0",
+        "tiny-warning": "^1.0.2"
+      }
+    },
     "mini-css-extract-plugin": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-0.5.0.tgz",
@@ -10120,6 +10156,52 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.6.tgz",
       "integrity": "sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA=="
     },
+    "react-router": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.0.1.tgz",
+      "integrity": "sha512-EM7suCPNKb1NxcTZ2LEOWFtQBQRQXecLxVpdsP4DW4PbbqYWeRiLyV/Tt1SdCrvT2jcyXAXmVTmzvSzrPR63Bg==",
+      "requires": {
+        "@babel/runtime": "^7.1.2",
+        "history": "^4.9.0",
+        "hoist-non-react-statics": "^3.1.0",
+        "loose-envify": "^1.3.1",
+        "mini-create-react-context": "^0.3.0",
+        "path-to-regexp": "^1.7.0",
+        "prop-types": "^15.6.2",
+        "react-is": "^16.6.0",
+        "tiny-invariant": "^1.0.2",
+        "tiny-warning": "^1.0.0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "path-to-regexp": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+          "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+          "requires": {
+            "isarray": "0.0.1"
+          }
+        }
+      }
+    },
+    "react-router-dom": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.0.1.tgz",
+      "integrity": "sha512-zaVHSy7NN0G91/Bz9GD4owex5+eop+KvgbxXsP/O+iW1/Ln+BrJ8QiIR5a6xNPtrdTvLkxqlDClx13QO1uB8CA==",
+      "requires": {
+        "@babel/runtime": "^7.1.2",
+        "history": "^4.9.0",
+        "loose-envify": "^1.3.1",
+        "prop-types": "^15.6.2",
+        "react-router": "5.0.1",
+        "tiny-invariant": "^1.0.2",
+        "tiny-warning": "^1.0.0"
+      }
+    },
     "react-scripts": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/react-scripts/-/react-scripts-3.0.1.tgz",
@@ -10505,6 +10587,11 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
       "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g="
+    },
+    "resolve-pathname": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-2.2.0.tgz",
+      "integrity": "sha512-bAFz9ld18RzJfddgrO2e/0S2O81710++chRMUxHjXOYKF6jTAMrUNZrEZ1PvV0zlhfjidm08iRPdTLPno1FuRg=="
     },
     "resolve-url": {
       "version": "0.2.1",
@@ -11611,6 +11698,16 @@
       "resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
       "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q="
     },
+    "tiny-invariant": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.0.4.tgz",
+      "integrity": "sha512-lMhRd/djQJ3MoaHEBrw8e2/uM4rs9YMNk0iOr8rHQ0QdbM7D4l0gFl3szKdeixrlyfm9Zqi4dxHCM2qVG8ND5g=="
+    },
+    "tiny-warning": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.2.tgz",
+      "integrity": "sha512-rru86D9CpQRLvsFG5XFdy0KdLAvjdQDyZCsRcuu60WtzFylDM3eAWSxEVz5kzL2Gp544XiUvPbVKtOA/txLi9Q=="
+    },
     "tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -12047,6 +12144,11 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
+    },
+    "value-equal": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-0.4.0.tgz",
+      "integrity": "sha512-x+cYdNnaA3CxvMaTX0INdTCN8m8aF2uY9BvEqmxuYp8bL09cs/kWVQPVGcA35fMktdOsP69IgU7wFj/61dJHEw=="
     },
     "vary": {
       "version": "1.1.2",

--- a/examples/user_interaction/client/package.json
+++ b/examples/user_interaction/client/package.json
@@ -15,6 +15,7 @@
     "@opencensus/web-all": "^0.0.2",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
+    "react-router-dom": "^5.0.1",
     "react-scripts": "3.0.1",
     "zone.js": "^0.9.1"
   },

--- a/examples/user_interaction/client/public/index.html
+++ b/examples/user_interaction/client/public/index.html
@@ -1,30 +1,37 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <title>OpenCensus Web User Interaction tracing</title>    
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="theme-color" content="#000000" />
-    <!--
+
+<head>
+  <title>OpenCensus Web User Interaction tracing</title>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="theme-color" content="#000000" />
+  <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
-    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-    <!-- Load bootstrap to see a resource load span -->
-    <link
-      href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.1/css/bootstrap.min.css"
-      rel="stylesheet"
-      integrity="sha384-WskhaSGFgHYWDcbwN70/dfYBj47jz9qbsMId/iRN3ewGhXQFZCSftd1LZCfmhktB"
-      crossorigin="anonymous">
-  </head>
-  <body>
-    <h1>OpenCensus Web User Interaction Tracing!</h1>
+  <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+  <!-- Load bootstrap to see a resource load span -->
+  <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.1/css/bootstrap.min.css" rel="stylesheet"
+    integrity="sha384-WskhaSGFgHYWDcbwN70/dfYBj47jz9qbsMId/iRN3ewGhXQFZCSftd1LZCfmhktB" crossorigin="anonymous">
+</head>
 
-    <p>This example demonstrates client side browser spans in the same trace as
-    server side spans for an initial page load and user iteractions.</p>
-    <p>The idea of this example is to show a series of network calls to Node.js backend when a button is clicked.
-      This example will shows how user interaction tracing works.
-    </p>
-    <div id="root"></div>
-  </body>
+<body>
+  <h1>OpenCensus Web User Interaction Tracing!</h1>
+
+  <p>
+    This example demonstrates client side browser spans in the same trace for an initial page load
+    and user iteractions.
+  </p>
+  <p>
+    Sample application that shows how user interaction tracing works.
+  </p>
+  <p>
+    The idea of this example is to show a series of network calls to Node.js backend and JS executions
+    when a button is clicked. Also, adds a route transition to show this use case and see the 'navigation'
+    naming approach.
+  </p>
+  <div id="root"></div>
+</body>
+
 </html>

--- a/examples/user_interaction/client/src/App.js
+++ b/examples/user_interaction/client/src/App.js
@@ -27,8 +27,6 @@ class App extends React.Component {
   }
 
   handleClick() {
-    console.log("Entering handle click.");
-
     // Use promises to test behavior on MicroTasks.
     const promise = new Promise(resolve => {
       setTimeout(function () {

--- a/examples/user_interaction/client/src/App.js
+++ b/examples/user_interaction/client/src/App.js
@@ -60,6 +60,7 @@ class App extends React.Component {
         const data = JSON.parse(xhr.responseText)
         const result = this.callCalculatePi();
         this.setState({ pi: result, prime_numbers: data });
+        this.props.history.push('/second_page');
       }
     };
 

--- a/examples/user_interaction/client/src/App.test.js
+++ b/examples/user_interaction/client/src/App.test.js
@@ -1,9 +1,0 @@
-import React from 'react';
-import ReactDOM from 'react-dom';
-import App from './App';
-
-it('renders without crashing', () => {
-  const div = document.createElement('div');
-  ReactDOM.render(<App />, div);
-  ReactDOM.unmountComponentAtNode(div);
-});

--- a/examples/user_interaction/client/src/SecondPage.js
+++ b/examples/user_interaction/client/src/SecondPage.js
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2019, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      gRPC://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+
+class SecondPage extends React.Component {
+
+  render() {
+    return (
+      <div>
+        <h5>Second page</h5>
+        <p>Rendering a second page in order to test the change of route and Navigation naming.</p>
+      </div>
+    );
+  }
+}
+
+export default SecondPage;

--- a/examples/user_interaction/client/src/index.js
+++ b/examples/user_interaction/client/src/index.js
@@ -17,13 +17,32 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import App from './App';
+import SecondPage from './SecondPage';
 import { exportRootSpanAfterLoadEvent } from '@opencensus/web-all';
 import { startInteractionTracker } from '@opencensus/web-instrumentation-zone';
 
+import { Route, BrowserRouter as Router, Link } from 'react-router-dom'
 // Necessary import for @opencensus/web-instrumentation-zone
 import { Zone, ZoneType, Task } from 'zone.js';
 
-ReactDOM.render(<App />, document.getElementById('root'));
+const routing = (
+    <Router>
+        <div>
+            <ul>
+                <li>
+                    <Link to="/">Home</Link>
+                </li>
+                <li>
+                    <Link to="/second_page">Second Page</Link>
+                </li>
+            </ul>
+            <Route exact path="/" component={App} />
+            <Route path="/second_page" component={SecondPage} />
+        </div>
+    </Router>
+)
+
+ReactDOM.render(routing, document.getElementById('root'));
 
 window.ocAgent = 'http://localhost:55678';
 window.ocSampleRate = 1.0; // Sample at 100% for test only. Default is 1/10000.

--- a/packages/opencensus-web-core/src/trace/model/tracer.ts
+++ b/packages/opencensus-web-core/src/trace/model/tracer.ts
@@ -69,10 +69,8 @@ export class Tracer extends TracerBase implements webTypes.Tracer {
         },
       },
     };
-    // Start the new zone from the current, for that, we assume
-    // all click handlers have the same parent zone.
-    const newZone = Zone.current.fork(zoneSpec);
 
+    const newZone = Zone.current.fork(zoneSpec);
     return newZone.run(() => {
       super.startRootSpan(options, root => {
         // Set the currentRootSpan to the new created root span.

--- a/packages/opencensus-web-core/src/trace/model/tracer.ts
+++ b/packages/opencensus-web-core/src/trace/model/tracer.ts
@@ -69,7 +69,9 @@ export class Tracer extends TracerBase implements webTypes.Tracer {
         },
       },
     };
-    const newZone = Zone.root.fork(zoneSpec);
+    // Start the new zone from the current, for that, we assume
+    // all click handlers have the same parent zone.
+    const newZone = Zone.current.fork(zoneSpec);
 
     return newZone.run(() => {
       super.startRootSpan(options, root => {

--- a/packages/opencensus-web-instrumentation-zone/src/interaction-tracker.ts
+++ b/packages/opencensus-web-instrumentation-zone/src/interaction-tracker.ts
@@ -70,6 +70,8 @@ export class InteractionTracker {
       );
       if (interceptingElement) {
         if (this.currentEventTracingZone === undefined && interactionName) {
+          // Starts the new zone from the Zone.current, for that, we assume
+          // all click handlers have the same parent zone.
           this.startNewInteraction(
             interceptingElement,
             task.eventName,
@@ -148,13 +150,13 @@ export class InteractionTracker {
       },
       kind: SpanKind.UNSPECIFIED,
     };
-    // Start a new RootSpan for a new user interaction, also, creates the new zone
-    // from the coming task.zone.
+    // Start a new RootSpan for a new user interaction forked from the original task.zone
     taskZone.run(() => {
       tracing.tracer.startRootSpan(spanOptions, root => {
         // As startRootSpan creates the zone and Zone.current corresponds to the
         // new zone, we have to set the currentEventTracingZone with the Zone.current
-        // to capture the new zone.
+        // to capture the new zone, also, start the `OnPageInteraction` to capture the 
+        // new root span.
         this.currentEventTracingZone = Zone.current;
         this.interactions[traceId] = startOnPageInteraction({
           startLocationHref: location.href,

--- a/packages/opencensus-web-instrumentation-zone/src/on-page-interaction.ts
+++ b/packages/opencensus-web-instrumentation-zone/src/on-page-interaction.ts
@@ -47,7 +47,7 @@ export class OnPageInteractionStopwatch {
     const rootSpan = this.data.rootSpan;
     rootSpan.addAttribute('EventType', this.data.eventType);
     rootSpan.addAttribute('TargetElement', this.data.target.tagName);
-    rootSpan.addAttribute(ATTRIBUTE_HTTP_URL, location.href);
+    rootSpan.addAttribute(ATTRIBUTE_HTTP_URL, this.data.originLocation);
     rootSpan.addAttribute(ATTRIBUTE_HTTP_USER_AGENT, navigator.userAgent);
     rootSpan.end();
     console.log('End of tracking. The interaction is stable.');

--- a/packages/opencensus-web-instrumentation-zone/src/on-page-interaction.ts
+++ b/packages/opencensus-web-instrumentation-zone/src/on-page-interaction.ts
@@ -18,6 +18,7 @@ import { OnPageInteractionData } from './zone-types';
 import {
   ATTRIBUTE_HTTP_URL,
   ATTRIBUTE_HTTP_USER_AGENT,
+  ATTRIBUTE_HTTP_PATH,
 } from '@opencensus/web-core';
 
 /** A helper class for tracking on page interactions. */
@@ -47,7 +48,8 @@ export class OnPageInteractionStopwatch {
     const rootSpan = this.data.rootSpan;
     rootSpan.addAttribute('EventType', this.data.eventType);
     rootSpan.addAttribute('TargetElement', this.data.target.tagName);
-    rootSpan.addAttribute(ATTRIBUTE_HTTP_URL, this.data.originLocation);
+    rootSpan.addAttribute(ATTRIBUTE_HTTP_URL, this.data.startLocationHref);
+    rootSpan.addAttribute(ATTRIBUTE_HTTP_PATH, this.data.startLocationPath);
     rootSpan.addAttribute(ATTRIBUTE_HTTP_USER_AGENT, navigator.userAgent);
     rootSpan.end();
     console.log('End of tracking. The interaction is stable.');

--- a/packages/opencensus-web-instrumentation-zone/src/zone-types.ts
+++ b/packages/opencensus-web-instrumentation-zone/src/zone-types.ts
@@ -31,6 +31,7 @@ export type AsyncTask = Task & {
 
 /** Data used to create a new OnPageInteractionStopwatch. */
 export interface OnPageInteractionData {
+  originLocation: string;
   eventType: string;
   target: HTMLElement;
   rootSpan: RootSpan;

--- a/packages/opencensus-web-instrumentation-zone/src/zone-types.ts
+++ b/packages/opencensus-web-instrumentation-zone/src/zone-types.ts
@@ -31,7 +31,8 @@ export type AsyncTask = Task & {
 
 /** Data used to create a new OnPageInteractionStopwatch. */
 export interface OnPageInteractionData {
-  originLocation: string;
+  startLocationHref: string;
+  startLocationPath: string;
   eventType: string;
   target: HTMLElement;
   rootSpan: RootSpan;


### PR DESCRIPTION
Monkey-patches `History API` to detect a route change and then maybe change the name of the interaction following the 'Navigation' naming approach.
Also, update the user interaction example to add a route transitions.