### PR TITLE
Refactor Tracer to check presence of Zone global variable

### DIFF
--- a/packages/opencensus-web-core/src/trace/model/tracing.ts
+++ b/packages/opencensus-web-core/src/trace/model/tracing.ts
@@ -23,7 +23,7 @@ export const NOOP_EXPORTER = new NoopExporter();
 /** Main interface for tracing. */
 export class Tracing implements webTypes.Tracing {
   /** Object responsible for managing a trace. */
-  readonly tracer = new Tracer();
+  readonly tracer = Tracer.instance;
 
   /** Service to send collected traces to. */
   exporter = NOOP_EXPORTER;

--- a/packages/opencensus-web-core/src/trace/model/types.ts
+++ b/packages/opencensus-web-core/src/trace/model/types.ts
@@ -1,0 +1,20 @@
+/**
+ * Copyright 2019, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** Interface to add `Zone` variable, used to check the `Zone` presence. */
+export interface WindowWithZone extends Window {
+  Zone?: Function;
+}

--- a/packages/opencensus-web-core/test/test-tracer.ts
+++ b/packages/opencensus-web-core/test/test-tracer.ts
@@ -16,16 +16,13 @@
 
 import * as webTypes from '@opencensus/web-types';
 import { Tracer } from '../src/trace/model/tracer';
-
-export interface WindowWithZone extends Window {
-  Zone?: Zone;
-}
+import { WindowWithZone } from '../src/trace/model/types';
 
 describe('Tracer', () => {
   let tracer: Tracer;
   let listener: webTypes.SpanEventListener;
   const options = { name: 'test' };
-  let realZone: Zone | undefined;
+  let realZone: Function | undefined;
   const windowWithZone = window as WindowWithZone;
 
   beforeEach(() => {

--- a/packages/opencensus-web-core/test/test-tracer.ts
+++ b/packages/opencensus-web-core/test/test-tracer.ts
@@ -17,10 +17,16 @@
 import * as webTypes from '@opencensus/web-types';
 import { Tracer } from '../src/trace/model/tracer';
 
+export interface WindowWithZone extends Window {
+  Zone?: Zone;
+}
+
 describe('Tracer', () => {
   let tracer: Tracer;
   let listener: webTypes.SpanEventListener;
   const options = { name: 'test' };
+  let realZone: Zone | undefined;
+  const windowWithZone = window as WindowWithZone;
 
   beforeEach(() => {
     tracer = new Tracer();
@@ -31,37 +37,113 @@ describe('Tracer', () => {
     tracer.eventListeners = [listener];
   });
 
-  /** Should get/set the current RootSpan from tracer instance */
-  describe('get/set currentRootSpan()', () => {
-    it('should get the current RootSpan from tracer instance', () => {
-      tracer.startRootSpan(options, root => {
-        expect(root).toBeTruthy();
-        expect(root).toBe(tracer.currentRootSpan);
+  describe('Zone is not present', () => {
+    beforeEach(() => {
+      realZone = windowWithZone.Zone;
+      windowWithZone.Zone = undefined;
+    });
+
+    afterEach(() => {
+      windowWithZone.Zone = realZone;
+    });
+
+    it('isZonePresent() is false', () => {
+      expect(tracer.isZonePresent()).toBeFalsy();
+    });
+
+    describe('get/set currentRootSpan()', () => {
+      // As `Zone` is not present, the current root span is accesible outside
+      // the callback as there is only one current root span.
+      it('should get the current RootSpan from tracer instance', () => {
+        const onStartFn = jasmine.createSpy('onStartFn');
+        tracer.startRootSpan(options, onStartFn);
+        const onStartRoot = onStartFn.calls.argsFor(0)[0];
+        expect(onStartRoot).toBe(tracer.currentRootSpan);
+      });
+    });
+
+    describe('startRootSpan', () => {
+      it('should create start RootSpan', () => {
+        const onStartFn = jasmine.createSpy('onStartFn');
+        const oldRoot = tracer.currentRootSpan;
+
+        tracer.startRootSpan(options, onStartFn);
+
+        expect(onStartFn).toHaveBeenCalled();
+        const onStartRoot = onStartFn.calls.argsFor(0)[0];
+        expect(onStartRoot.name).toBe('test');
+        expect(onStartRoot).not.toBe(oldRoot);
+        expect(tracer.currentRootSpan).toBe(onStartRoot);
+        expect(listener.onStartSpan).toHaveBeenCalledWith(onStartRoot);
+      });
+    });
+
+    describe('startChildSpan', () => {
+      it('starts a child span of the current root span', () => {
+        spyOn(tracer.currentRootSpan, 'startChildSpan');
+        tracer.startChildSpan({
+          name: 'child1',
+          kind: webTypes.SpanKind.CLIENT,
+        });
+        expect(tracer.currentRootSpan.startChildSpan).toHaveBeenCalledWith({
+          childOf: tracer.currentRootSpan,
+          name: 'child1',
+          kind: webTypes.SpanKind.CLIENT,
+        });
       });
     });
   });
 
-  describe('startRootSpan', () => {
-    it('should create a new RootSpan instance', () => {
-      tracer.startRootSpan(options, rootSpan => {
-        expect(rootSpan).toBeTruthy();
+  describe('Zone is present', () => {
+    /** Should get/set the current RootSpan from tracer instance */
+    describe('get/set currentRootSpan()', () => {
+      it('should get the current RootSpan from tracer instance', () => {
+        tracer.startRootSpan(options, root => {
+          expect(root).toBeTruthy();
+          expect(root).toBe(tracer.currentRootSpan);
+        });
       });
     });
-    it('sets current root span', () => {
-      const oldRoot = tracer.currentRootSpan;
 
-      tracer.startRootSpan(options, rootSpan => {
-        expect(rootSpan.name).toBe('test');
-        expect(rootSpan).not.toBe(oldRoot);
-        expect(tracer.currentRootSpan).toBe(rootSpan);
-        expect(listener.onStartSpan).toHaveBeenCalledWith(rootSpan);
+    describe('startRootSpan', () => {
+      it('should create a new RootSpan instance', () => {
+        tracer.startRootSpan(options, rootSpan => {
+          expect(rootSpan).toBeTruthy();
+        });
+      });
+      it('sets current root span', () => {
+        const oldRoot = tracer.currentRootSpan;
+
+        tracer.startRootSpan(options, rootSpan => {
+          expect(rootSpan.name).toBe('test');
+          expect(rootSpan).not.toBe(oldRoot);
+          expect(tracer.currentRootSpan).toBe(rootSpan);
+          expect(listener.onStartSpan).toHaveBeenCalledWith(rootSpan);
+        });
+      });
+      it('should create a new Zone and RootSpan associated to the zone', () => {
+        tracer.startRootSpan(options, rootSpan => {
+          expect(rootSpan).toBeTruthy();
+          expect(Zone.current).not.toBe(Zone.root);
+          expect(Zone.current.get('data').rootSpan).toBe(rootSpan);
+        });
       });
     });
-    it('should create a new Zone and RootSpan an associated to the zone', () => {
-      tracer.startRootSpan(options, rootSpan => {
-        expect(rootSpan).toBeTruthy();
-        expect(Zone.current).not.toBe(Zone.root);
-        expect(Zone.current.get('data').rootSpan).toBe(rootSpan);
+
+    describe('startChildSpan', () => {
+      let rootSpanLocal: webTypes.Span;
+      let span: webTypes.Span;
+      it('starts a child span of the current root span', () => {
+        tracer.startRootSpan(options, rootSpan => {
+          rootSpanLocal = rootSpan;
+          span = tracer.startChildSpan({
+            name: 'child1',
+            kind: webTypes.SpanKind.CLIENT,
+          });
+        });
+        expect(span).toBeTruthy();
+        expect(rootSpanLocal.numberOfChildren).toBe(1);
+        expect(rootSpanLocal.spans[0]).toBe(span);
       });
     });
   });
@@ -71,23 +153,6 @@ describe('Tracer', () => {
       const oldRoot = tracer.currentRootSpan;
       tracer.clearCurrentTrace();
       expect(tracer.currentRootSpan).not.toBe(oldRoot);
-    });
-  });
-
-  describe('startChildSpan', () => {
-    let rootSpanLocal: webTypes.Span;
-    let span: webTypes.Span;
-    it('starts a child span of the current root span', () => {
-      tracer.startRootSpan(options, rootSpan => {
-        rootSpanLocal = rootSpan;
-        span = tracer.startChildSpan({
-          name: 'child1',
-          kind: webTypes.SpanKind.CLIENT,
-        });
-      });
-      expect(span).toBeTruthy();
-      expect(rootSpanLocal.numberOfChildren).toBe(1);
-      expect(rootSpanLocal.spans[0]).toBe(span);
     });
   });
 


### PR DESCRIPTION
This checks the presence of `Zone` in Tracer as there might be some case where `zone.js` library is not imported.
Also, modify `Tracer` to be Singleton as there will be only one instance.