### PR TITLE
Propagate trace context header

### DIFF
--- a/examples/user_interaction/client/src/App.js
+++ b/examples/user_interaction/client/src/App.js
@@ -58,7 +58,6 @@ class App extends React.Component {
         const data = JSON.parse(xhr.responseText)
         const result = this.callCalculatePi();
         this.setState({ pi: result, prime_numbers: data });
-        this.props.history.push('/second_page');
       }
     };
 

--- a/examples/user_interaction/client/src/index.js
+++ b/examples/user_interaction/client/src/index.js
@@ -45,7 +45,7 @@ const routing = (
 ReactDOM.render(routing, document.getElementById('root'));
 
 window.ocAgent = 'http://localhost:55678';
-// For the purpose of this example, just match all hosts.
+// For the purpose of this example, send trace header to all hosts.
 window.ocTraceHeaderHostRegex = /.*/;
 window.ocSampleRate = 1.0; // Sample at 100% for test only. Default is 1/10000.
 

--- a/examples/user_interaction/client/src/index.js
+++ b/examples/user_interaction/client/src/index.js
@@ -45,7 +45,8 @@ const routing = (
 ReactDOM.render(routing, document.getElementById('root'));
 
 window.ocAgent = 'http://localhost:55678';
-window.ocTraceOrigins = 'http://localhost:3000';
+// For the purpose of this example, just match all hosts.
+window.ocTraceHeaderHostRegex = /.*/;
 window.ocSampleRate = 1.0; // Sample at 100% for test only. Default is 1/10000.
 
 // Send the root span and child spans for the initial page load to the

--- a/examples/user_interaction/client/src/index.js
+++ b/examples/user_interaction/client/src/index.js
@@ -45,6 +45,7 @@ const routing = (
 ReactDOM.render(routing, document.getElementById('root'));
 
 window.ocAgent = 'http://localhost:55678';
+window.ocTraceOrigins = 'http://localhost:3000';
 window.ocSampleRate = 1.0; // Sample at 100% for test only. Default is 1/10000.
 
 // Send the root span and child spans for the initial page load to the

--- a/examples/user_interaction/server/package-lock.json
+++ b/examples/user_interaction/server/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@opencensus/core": {
-      "version": "0.0.12",
-      "resolved": "https://registry.npmjs.org/@opencensus/core/-/core-0.0.12.tgz",
-      "integrity": "sha512-zc9Nbuci7VrcCbtZVv0zP2RMPXc2zv40VU79ODp4u0ZHqcXZmogFTwAsB7Nh8/23k5yP6qmbdruZYgeq4N6+KQ==",
+      "version": "0.0.14",
+      "resolved": "https://registry.npmjs.org/@opencensus/core/-/core-0.0.14.tgz",
+      "integrity": "sha512-JozZkTqm57/g1RfMqZ9ZiJrrJ1O4UnVetVTW2e+AFa0fW+Zam5xBD8UmfNAYy/pIYfejknKEO6x9LFW95bbxcw==",
       "requires": {
         "continuation-local-storage": "^3.2.1",
         "log-driver": "^1.2.7",
@@ -17,34 +17,34 @@
       }
     },
     "@opencensus/exporter-zipkin": {
-      "version": "0.0.12",
-      "resolved": "https://registry.npmjs.org/@opencensus/exporter-zipkin/-/exporter-zipkin-0.0.12.tgz",
-      "integrity": "sha512-+Awh+1X5mz452WMJMUQHQuneL7pqC2e4GC5APFN07Uxp+duKTDbU/qj3//WskC/GlhWMX3JVxYhYa/IrRAGQmw==",
+      "version": "0.0.14",
+      "resolved": "https://registry.npmjs.org/@opencensus/exporter-zipkin/-/exporter-zipkin-0.0.14.tgz",
+      "integrity": "sha512-nh1nROJMaHDy7JgdDtRgSZRvIgl6UsUVQkGO5Qe7TymU4BC4MAkIGGL2Mi8QoSj/Uih7NjO+HvK12Ste6qLUMA==",
       "requires": {
-        "@opencensus/core": "^0.0.12"
+        "@opencensus/core": "^0.0.14"
       }
     },
     "@opencensus/instrumentation-all": {
-      "version": "0.0.12",
-      "resolved": "https://registry.npmjs.org/@opencensus/instrumentation-all/-/instrumentation-all-0.0.12.tgz",
-      "integrity": "sha512-3QRovWX9rKvULiLmOj+oupibakaG4kkAkhGxWncVGTq+q2jxVw6yyRmHU0o79OHwRVkQSSnsWZ9pI7I3g/Nnig==",
+      "version": "0.0.14",
+      "resolved": "https://registry.npmjs.org/@opencensus/instrumentation-all/-/instrumentation-all-0.0.14.tgz",
+      "integrity": "sha512-IlqGnQHlL4iCUrpdUZzkBTclDJVRXHgOWdzRkSF77mx3MR4Z9H0fxZl4pZ1/1MHH3QrVAZeFarmo1X4lRfgY7Q==",
       "requires": {
-        "@opencensus/instrumentation-grpc": "^0.0.12",
-        "@opencensus/instrumentation-http": "^0.0.12",
-        "@opencensus/instrumentation-http2": "^0.0.12",
-        "@opencensus/instrumentation-https": "^0.0.12",
-        "@opencensus/instrumentation-ioredis": "^0.0.12",
-        "@opencensus/instrumentation-mongodb": "^0.0.12",
-        "@opencensus/instrumentation-redis": "^0.0.12"
+        "@opencensus/instrumentation-grpc": "^0.0.14",
+        "@opencensus/instrumentation-http": "^0.0.14",
+        "@opencensus/instrumentation-http2": "^0.0.14",
+        "@opencensus/instrumentation-https": "^0.0.14",
+        "@opencensus/instrumentation-ioredis": "^0.0.14",
+        "@opencensus/instrumentation-mongodb": "^0.0.14",
+        "@opencensus/instrumentation-redis": "^0.0.14"
       }
     },
     "@opencensus/instrumentation-grpc": {
-      "version": "0.0.12",
-      "resolved": "https://registry.npmjs.org/@opencensus/instrumentation-grpc/-/instrumentation-grpc-0.0.12.tgz",
-      "integrity": "sha512-wTUq8tj23X5e2NDMVdP9BdFVN1rPOPUvXT8yUnjuNSPZHu1Wm3GTvGC0pyFHFY/WmUAEy8uqwqaBOKKNt6qO3g==",
+      "version": "0.0.14",
+      "resolved": "https://registry.npmjs.org/@opencensus/instrumentation-grpc/-/instrumentation-grpc-0.0.14.tgz",
+      "integrity": "sha512-iA7vrkXs2OhuINS344FZ1IDwM25r7z3pETmdEzDmX1b/jQzxfW1uS0FKg1a/Wvzm5B3ZVs7NY40gdtXGl27j7A==",
       "requires": {
-        "@opencensus/core": "^0.0.12",
-        "@opencensus/propagation-binaryformat": "^0.0.12",
+        "@opencensus/core": "^0.0.14",
+        "@opencensus/propagation-binaryformat": "^0.0.14",
         "grpc": "~1.20.0",
         "lodash": "^4.17.11",
         "object-sizeof": "^1.3.0",
@@ -52,100 +52,100 @@
       }
     },
     "@opencensus/instrumentation-http": {
-      "version": "0.0.12",
-      "resolved": "https://registry.npmjs.org/@opencensus/instrumentation-http/-/instrumentation-http-0.0.12.tgz",
-      "integrity": "sha512-J/CkeTxy85Pox/asxM+rVTrTRehk/5qIvrRYr2el+14XVKfdVjpWPLYS8D1aZAkQ88CUwBah87gbCCS6oVSqSA==",
+      "version": "0.0.14",
+      "resolved": "https://registry.npmjs.org/@opencensus/instrumentation-http/-/instrumentation-http-0.0.14.tgz",
+      "integrity": "sha512-XckkLFH2R+0SHetncxxAaf+DOvUfzlVf/hzeuY4qySTB6N8456tQG26iODn2RuaBNeZ6BRR6qTyY6FrR90XD+Q==",
       "requires": {
-        "@opencensus/core": "^0.0.12",
+        "@opencensus/core": "^0.0.14",
         "semver": "^6.0.0",
         "shimmer": "^1.2.0"
       }
     },
     "@opencensus/instrumentation-http2": {
-      "version": "0.0.12",
-      "resolved": "https://registry.npmjs.org/@opencensus/instrumentation-http2/-/instrumentation-http2-0.0.12.tgz",
-      "integrity": "sha512-Pi0Lr70xMRzMNOy+J/6ScahbwRktZmzcrrbkVbJ5gaUJFxK2dRNmZfHZqgdQK41UoVklibd4aLqrn9aJBTisZg==",
+      "version": "0.0.14",
+      "resolved": "https://registry.npmjs.org/@opencensus/instrumentation-http2/-/instrumentation-http2-0.0.14.tgz",
+      "integrity": "sha512-8M/jmeyM4ybcJH/eqZzZyhrOZnFgsIzARSZ8SVGSXlmSB+riGRTqKzF0BTHIsOhLhi9L1H0dTEoRFcIhSEGHrQ==",
       "requires": {
-        "@opencensus/core": "^0.0.12",
-        "@opencensus/instrumentation-http": "^0.0.12",
+        "@opencensus/core": "^0.0.14",
+        "@opencensus/instrumentation-http": "^0.0.14",
         "semver": "^6.0.0",
         "shimmer": "^1.2.0"
       }
     },
     "@opencensus/instrumentation-https": {
-      "version": "0.0.12",
-      "resolved": "https://registry.npmjs.org/@opencensus/instrumentation-https/-/instrumentation-https-0.0.12.tgz",
-      "integrity": "sha512-pyJvGW6+Abh+tLcIvloD3eu8Q4pm3QjWVN8QPv7z8fUXYe/Whozjb7pJ1dZSB1EAEGhjdB+muzHDt2OCjz4TAQ==",
+      "version": "0.0.14",
+      "resolved": "https://registry.npmjs.org/@opencensus/instrumentation-https/-/instrumentation-https-0.0.14.tgz",
+      "integrity": "sha512-ttJBs5WQ5wxGQ7m9rjyPqqJpY/2LexJJokbB55+IyrZgh4xKYPS1dCgOlDTOwzOhPg8ok3bjicqc+9+Pl2kSZA==",
       "requires": {
-        "@opencensus/core": "^0.0.12",
-        "@opencensus/instrumentation-http": "^0.0.12",
+        "@opencensus/core": "^0.0.14",
+        "@opencensus/instrumentation-http": "^0.0.14",
         "semver": "^6.0.0",
         "shimmer": "^1.2.0"
       }
     },
     "@opencensus/instrumentation-ioredis": {
-      "version": "0.0.12",
-      "resolved": "https://registry.npmjs.org/@opencensus/instrumentation-ioredis/-/instrumentation-ioredis-0.0.12.tgz",
-      "integrity": "sha512-2Qt3anwq7xQnGkxu+0DV8+Ws6s6Fm3F6RzHLms9ZLnvFBHrn5JuLwFox9Hxryurx1Tajj8K60c8QIOOuUwMqDA==",
+      "version": "0.0.14",
+      "resolved": "https://registry.npmjs.org/@opencensus/instrumentation-ioredis/-/instrumentation-ioredis-0.0.14.tgz",
+      "integrity": "sha512-98nmx2s1jHuFq0drsxbhKzt7sj8gKqS6JWxD1Zv/DqtCmcH/e+chH592QRjCUIIk0xRFsYKP+AhgDR0PcOoUEg==",
       "requires": {
-        "@opencensus/core": "^0.0.12",
+        "@opencensus/core": "^0.0.14",
         "semver": "^6.0.0",
         "shimmer": "^1.2.0"
       }
     },
     "@opencensus/instrumentation-mongodb": {
-      "version": "0.0.12",
-      "resolved": "https://registry.npmjs.org/@opencensus/instrumentation-mongodb/-/instrumentation-mongodb-0.0.12.tgz",
-      "integrity": "sha512-/jvrLFLiGq588Dar7tlyJiiUfSPQrNfS1A0PaiH3BjewmANJ2JMLO4SarkI8Uy4ojftVdiRYDRLMYufvGeQpng==",
+      "version": "0.0.14",
+      "resolved": "https://registry.npmjs.org/@opencensus/instrumentation-mongodb/-/instrumentation-mongodb-0.0.14.tgz",
+      "integrity": "sha512-T29xAVbMAU0HJBYgm8IkKMkH9xisbbqSAjouBKuZir3HigbEUXeqmnwuoh7Ht3HXQKYwYn8CR+a6a1RplQOJgA==",
       "requires": {
-        "@opencensus/core": "^0.0.12",
+        "@opencensus/core": "^0.0.14",
         "shimmer": "^1.2.0"
       }
     },
     "@opencensus/instrumentation-redis": {
-      "version": "0.0.12",
-      "resolved": "https://registry.npmjs.org/@opencensus/instrumentation-redis/-/instrumentation-redis-0.0.12.tgz",
-      "integrity": "sha512-KvdKfCRK08xkbmAkfv4miyI/y6/lT8WSbo1RHhHLe8I58IBcCZghhoB293J99YJEDPeMHLeebqRMCdL+x/MPRA==",
+      "version": "0.0.14",
+      "resolved": "https://registry.npmjs.org/@opencensus/instrumentation-redis/-/instrumentation-redis-0.0.14.tgz",
+      "integrity": "sha512-s2HpF+CDQmUxDJjvO3obdWRBGX/up+XgfJsT7s/EeDXa4L4R/bMZ1xkYhvEfKySmgefw6UL3hRPXL4M1l9Cekg==",
       "requires": {
-        "@opencensus/core": "^0.0.12",
+        "@opencensus/core": "^0.0.14",
         "semver": "^6.0.0",
         "shimmer": "^1.2.0"
       }
     },
     "@opencensus/nodejs": {
-      "version": "0.0.12",
-      "resolved": "https://registry.npmjs.org/@opencensus/nodejs/-/nodejs-0.0.12.tgz",
-      "integrity": "sha512-lvaqGXpzBtWw8k1JM7n9Hm9x5v5BnDU9gGDWRLK6GADX+yBVdDjkiM0Rk7wmVSog6Sx5HvlA7R6gwK5P684SXA==",
+      "version": "0.0.14",
+      "resolved": "https://registry.npmjs.org/@opencensus/nodejs/-/nodejs-0.0.14.tgz",
+      "integrity": "sha512-MV12e6sXTKV5C8DKbHXKRNEB6QeKOKQoTzRmAgbGd9tPDNkEWiXm6VWgoR5XW3LRcOu4ZITQ9bWwuwFBip23Pg==",
       "requires": {
-        "@opencensus/core": "^0.0.12",
-        "@opencensus/instrumentation-all": "^0.0.12",
-        "@opencensus/nodejs-base": "^0.0.12"
+        "@opencensus/core": "^0.0.14",
+        "@opencensus/instrumentation-all": "^0.0.14",
+        "@opencensus/nodejs-base": "^0.0.14"
       }
     },
     "@opencensus/nodejs-base": {
-      "version": "0.0.12",
-      "resolved": "https://registry.npmjs.org/@opencensus/nodejs-base/-/nodejs-base-0.0.12.tgz",
-      "integrity": "sha512-+qo2HKCj8D6uDTUWvAbRVUEA0JFDGKS5fOJfvsvw0KQK9suNCVYginCUMHGCv6kynHSyfe4XQdlQuOY5trlrDw==",
+      "version": "0.0.14",
+      "resolved": "https://registry.npmjs.org/@opencensus/nodejs-base/-/nodejs-base-0.0.14.tgz",
+      "integrity": "sha512-Avsg6C1i8UMfE8B+Rp8qr7OMMzy0pTlupH1ddJ59vaePP0YqL4cXJuutHsruf2QTW28eNuSGDtjmtk7F4ksXoA==",
       "requires": {
-        "@opencensus/core": "^0.0.12",
+        "@opencensus/core": "^0.0.14",
         "extend": "^3.0.2",
         "require-in-the-middle": "^4.0.0"
       }
     },
     "@opencensus/propagation-binaryformat": {
-      "version": "0.0.12",
-      "resolved": "https://registry.npmjs.org/@opencensus/propagation-binaryformat/-/propagation-binaryformat-0.0.12.tgz",
-      "integrity": "sha512-2mdSS2jO2hm2dnq/2avXgxhz635guKIVOGdVjcKgKqdAXZbgofu0NurmjMkmJpLnlkiDWxou9OeBcdW29m3N3w==",
+      "version": "0.0.14",
+      "resolved": "https://registry.npmjs.org/@opencensus/propagation-binaryformat/-/propagation-binaryformat-0.0.14.tgz",
+      "integrity": "sha512-OKqjHZW153moG7dOApY1G6WeyMPm0auqqMmYXiyY9h7cYqtVExqhAJlUnkfKhN5g5729EDgmOoz/h8FpY1oD0Q==",
       "requires": {
-        "@opencensus/core": "^0.0.12"
+        "@opencensus/core": "^0.0.14"
       }
     },
     "@opencensus/propagation-tracecontext": {
-      "version": "0.0.12",
-      "resolved": "https://registry.npmjs.org/@opencensus/propagation-tracecontext/-/propagation-tracecontext-0.0.12.tgz",
-      "integrity": "sha512-n/1lBJLu0kDlZbdjrxueXAWUQrGBq4+G5tyZBJt9m/vtpDGrJiciv8yzjP/VGC5ov/BVLtuJUBboplwgUaQVpQ==",
+      "version": "0.0.14",
+      "resolved": "https://registry.npmjs.org/@opencensus/propagation-tracecontext/-/propagation-tracecontext-0.0.14.tgz",
+      "integrity": "sha512-pW6KsysjrKepAAbM18mwqxQShIYYfj78cPKu/JUN5mDJBTYEWXJl8pDLMk0tSMs3/zSiFLd7Kbr+fPfibSOjoQ==",
       "requires": {
-        "@opencensus/core": "^0.0.12"
+        "@opencensus/core": "^0.0.14"
       }
     },
     "acorn": {
@@ -1863,11 +1863,11 @@
       "dev": true
     },
     "object-sizeof": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/object-sizeof/-/object-sizeof-1.3.1.tgz",
-      "integrity": "sha512-XkAMI9e1Dbtw28Th2Q+FQxA7ZUB4dIPyIpDgKNtmzIaYL1pcPtmFgfekwVjs1PVpdcMfzU/t2qNW8biOMe/tOA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/object-sizeof/-/object-sizeof-1.4.0.tgz",
+      "integrity": "sha512-ehpLH3Jjs3tGVzhkPYC+z0Cczpx5FZnCaCmWS4GkxZnGgGB1jCWSju8WTRdCGmCRNoXidmBurDyzaDiZVlOrVw==",
       "requires": {
-        "buffer": "^5.0.6"
+        "buffer": "^5.2.1"
       }
     },
     "once": {
@@ -2237,9 +2237,9 @@
       }
     },
     "semver": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.0.0.tgz",
-      "integrity": "sha512-0UewU+9rFapKFnlbirLi3byoOuhrSsli/z/ihNnvM24vgF+8sNBiI1LZPBSH9wJKUwaUbw+s3hToDLCXkrghrQ=="
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.1.3.tgz",
+      "integrity": "sha512-aymF+56WJJMyXQHcd4hlK4N75rwj5RQpfW8ePlQnJsTYOBLlLbcIErR/G1s9SkIvKBqOudR3KAx4wEqP+F1hNQ=="
     },
     "shebang-command": {
       "version": "1.2.0",

--- a/examples/user_interaction/server/package.json
+++ b/examples/user_interaction/server/package.json
@@ -21,9 +21,9 @@
     "node": ">=8"
   },
   "dependencies": {
-    "@opencensus/exporter-zipkin": "^0.0.12",
-    "@opencensus/nodejs": "^0.0.12",
-    "@opencensus/propagation-tracecontext": "^0.0.12",
+    "@opencensus/exporter-zipkin": "^0.0.14",
+    "@opencensus/nodejs": "^0.0.14",
+    "@opencensus/propagation-tracecontext": "^0.0.14",
     "http": "*",
     "sleep": "^6.1.0"
   },

--- a/examples/user_interaction/server/server.js
+++ b/examples/user_interaction/server/server.js
@@ -78,7 +78,8 @@ function handleRequest(request, response) {
 
     let result = '';
     let code = 200;
-    if(request.method !== 'GET'){
+    // Logic related to CORS pre-flight requests.
+    if(request.method === 'OPTIONS'){
       request.on('end', () => {
         span.end();
         response.statusCode = code;

--- a/examples/user_interaction/server/server.js
+++ b/examples/user_interaction/server/server.js
@@ -63,7 +63,7 @@ function calculatePrimeNumbers() {
 
 /** A function which handles requests and send response. */
 function handleRequest(request, response) {
-  const span = tracer.startChildSpan({ name: 'octutorials.handleRequest' });
+  const span = tracer.startChildSpan({ name: 'ocweb.handleRequest' });
 
   try {
     let body = [];
@@ -72,16 +72,24 @@ function handleRequest(request, response) {
 
     // Necessary headers because the Node.js and React dev servers run in different ports.
     response.setHeader('Access-Control-Allow-Origin', '*');
-    response.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS, PUT, PATCH, DELETE');
-    response.setHeader('Access-Control-Allow-Headers', 'X-Requested-With,content-type');
+    response.setHeader('Access-Control-Allow-Methods', 'GET, OPTIONS');
+    response.setHeader('Access-Control-Allow-Headers', 'traceparent');
     response.setHeader('Access-Control-Allow-Credentials', true);
 
     let result = '';
     let code = 200;
+    if(request.method !== 'GET'){
+      request.on('end', () => {
+        span.end();
+        response.statusCode = code;
+        response.end();
+      });
+      return;
+    }
     if (url.parse(request.url).pathname === '/sleep') {
       console.log("Sleeping...")
       const time = Date.now();
-      sleep.sleep(5);
+      sleep.sleep(2);
       result = { time: Date.now() - time, value: "" };
       console.log("Finished.")
     } else if (url.parse(request.url).pathname === '/prime_numbers') {
@@ -109,7 +117,7 @@ function handleRequest(request, response) {
 function setupTracerAndExporters() {
   const zipkinOptions = {
     url: 'http://localhost:9411/api/v2/spans',
-    serviceName: 'opencensus_tutorial'
+    serviceName: 'opencensus_web_server'
   };
 
   // Creates Zipkin exporter

--- a/examples/user_interaction/server/server.js
+++ b/examples/user_interaction/server/server.js
@@ -70,16 +70,16 @@ function handleRequest(request, response) {
     request.on('error', err => console.log(err));
     request.on('data', chunk => body.push(chunk));
 
-    // Necessary headers because the Node.js and React dev servers run in different ports.
-    response.setHeader('Access-Control-Allow-Origin', '*');
-    response.setHeader('Access-Control-Allow-Methods', 'GET, OPTIONS');
-    response.setHeader('Access-Control-Allow-Headers', 'traceparent');
-    response.setHeader('Access-Control-Allow-Credentials', true);
-
+    // Necessary header because the Node.js and React dev servers run in different ports.
+    response.setHeader('Access-Control-Allow-Origin', '*');    
+    
     let result = '';
     let code = 200;
-    // Logic related to CORS pre-flight requests.
+    // Accept all CORS pre-flight requests
     if(request.method === 'OPTIONS'){
+      // Set headers to allow traceparent and subsequent get request.
+      response.setHeader('Access-Control-Allow-Headers', 'traceparent');
+      response.setHeader('Access-Control-Allow-Methods', 'GET');
       request.on('end', () => {
         span.end();
         response.statusCode = code;

--- a/packages/opencensus-web-instrumentation-zone/package-lock.json
+++ b/packages/opencensus-web-instrumentation-zone/package-lock.json
@@ -174,6 +174,14 @@
         "@opencensus/web-core": "^0.0.3"
       }
     },
+    "@opencensus/web-propagation-tracecontext": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@opencensus/web-propagation-tracecontext/-/web-propagation-tracecontext-0.0.3.tgz",
+      "integrity": "sha512-YXOi38GscRLIorFFhLl7ZQqcO8bzDVCo7qdbeExKI+hzyuC3RygswqQt7P9j23tnfoRBPTHxKwbJAY3JZYBcbw==",
+      "requires": {
+        "@opencensus/web-core": "^0.0.3"
+      }
+    },
     "@opencensus/web-types": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/@opencensus/web-types/-/web-types-0.0.3.tgz",

--- a/packages/opencensus-web-instrumentation-zone/package.json
+++ b/packages/opencensus-web-instrumentation-zone/package.json
@@ -68,7 +68,8 @@
   },
   "dependencies": {
     "@opencensus/web-core": "^0.0.3",
-    "@opencensus/web-exporter-ocagent": "^0.0.3"
+    "@opencensus/web-exporter-ocagent": "^0.0.3",
+    "@opencensus/web-propagation-tracecontext": "0.0.3"
   },
   "peerDependencies": {
     "zone.js": "~0.9.1"

--- a/packages/opencensus-web-instrumentation-zone/src/export-interaction-tracker.ts
+++ b/packages/opencensus-web-instrumentation-zone/src/export-interaction-tracker.ts
@@ -24,6 +24,7 @@ const windowWithOcwGlobals = window as WindowWithOcwGlobals;
 const TRACE_ENDPOINT = '/v1/trace';
 
 import { InteractionTracker } from './interaction-tracker';
+import { doPatching } from './monkey-patching';
 
 function setupExporter() {
   if (!windowWithOcwGlobals.ocAgent) {
@@ -39,6 +40,7 @@ function setupExporter() {
 }
 
 export function startInteractionTracker() {
+  doPatching();
   setupExporter();
   InteractionTracker.startTracking();
 }

--- a/packages/opencensus-web-instrumentation-zone/src/monkey-patching.ts
+++ b/packages/opencensus-web-instrumentation-zone/src/monkey-patching.ts
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2019, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { XHRWithUrl } from './zone-types';
+
+export function doPatching() {
+  patchXMLHttpRequestOpen();
+}
+
+// Patch the `XMLHttpRequest.open` method to add method used for the request
+function patchXMLHttpRequestOpen() {
+  const open = XMLHttpRequest.prototype.open;
+
+  XMLHttpRequest.prototype.open = function(
+    method: string,
+    url: string,
+    async?: boolean,
+    user?: string | null,
+    pass?: string | null
+  ) {
+    if (async) {
+      open.call(this, method, url, async, user, pass);
+    } else {
+      open.call(this, method, url, true, null, null);
+    }
+    (this as XHRWithUrl)._ocweb_method = method;
+  };
+}

--- a/packages/opencensus-web-instrumentation-zone/src/monkey-patching.ts
+++ b/packages/opencensus-web-instrumentation-zone/src/monkey-patching.ts
@@ -20,7 +20,9 @@ export function doPatching() {
   patchXMLHttpRequestOpen();
 }
 
-// Patch the `XMLHttpRequest.open` method to add method used for the request
+// Patch the `XMLHttpRequest.open` method to add method used for the request.
+// This patch is needed because Zone.js does not capture the method from XHR
+// the way that it captures URL as __zone_symbol__xhrURL.
 function patchXMLHttpRequestOpen() {
   const open = XMLHttpRequest.prototype.open;
 

--- a/packages/opencensus-web-instrumentation-zone/src/util.ts
+++ b/packages/opencensus-web-instrumentation-zone/src/util.ts
@@ -18,12 +18,12 @@ import { WindowWithOcwGlobals } from './zone-types';
 import { parseUrl } from '@opencensus/web-core';
 
 /** Check that the trace */
-export function traceOriginMatchesOrSameOrigin(): boolean {
-  const traceOrigin = (window as WindowWithOcwGlobals).ocTraceOrigins as string;
-  if (!traceOrigin) return false;
-  const parsedUrl = parseUrl(traceOrigin);
-  const regex = /.*/;
+export function traceOriginMatchesOrSameOrigin(xhrUrl: string): boolean {
+  const traceHeaderHostRegex = (window as WindowWithOcwGlobals)
+    .ocTraceHeaderHostRegex as string;
+  const parsedUrl = parseUrl(xhrUrl);
 
   if (parsedUrl.origin === location.origin) return true;
-  return !!parsedUrl.host.match(regex);
+
+  return !!(traceHeaderHostRegex && parsedUrl.host.match(traceHeaderHostRegex));
 }

--- a/packages/opencensus-web-instrumentation-zone/src/util.ts
+++ b/packages/opencensus-web-instrumentation-zone/src/util.ts
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2019, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { WindowWithOcwGlobals } from './zone-types';
+import { parseUrl } from '@opencensus/web-core';
+
+/** Check that the trace */
+export function traceOriginMatchesOrSameOrigin(): boolean {
+  const traceOrigin = (window as WindowWithOcwGlobals).ocTraceOrigins as string;
+  if (!traceOrigin) return false;
+  const parsedUrl = parseUrl(traceOrigin);
+  const regex = /.*/;
+
+  if (parsedUrl.origin === location.origin) return true;
+  return !!parsedUrl.host.match(regex);
+}

--- a/packages/opencensus-web-instrumentation-zone/src/zone-types.ts
+++ b/packages/opencensus-web-instrumentation-zone/src/zone-types.ts
@@ -38,6 +38,13 @@ export interface OnPageInteractionData {
   rootSpan: RootSpan;
 }
 
+/** Allows monkey-patching XMLHttpRequest and to obtain the request URL. */
+export type XHRWithUrl = HTMLElement &
+  XMLHttpRequest & {
+    __zone_symbol__xhrURL: string;
+    _ocweb_method: string;
+  };
+
 /** Type for `window` object with variables OpenCensus Web interacts with. */
 export declare interface WindowWithOcwGlobals extends Window {
   /**
@@ -51,4 +58,7 @@ export declare interface WindowWithOcwGlobals extends Window {
    * specified sample rate. If not specified, a default sampling rate is used.
    */
   ocSampleRate?: number;
+
+  //
+  ocTraceOrigins?: string;
 }

--- a/packages/opencensus-web-instrumentation-zone/src/zone-types.ts
+++ b/packages/opencensus-web-instrumentation-zone/src/zone-types.ts
@@ -38,7 +38,11 @@ export interface OnPageInteractionData {
   rootSpan: RootSpan;
 }
 
-/** Allows monkey-patching XMLHttpRequest and to obtain the request URL. */
+/**
+ * Allows monkey-patching XMLHttpRequest and to obtain the request URL.
+ * `HTMLElement` is necessary when the xhr is captured from the tasks target
+ *  as the Zone monkey-patch parses xhrs as `HTMLElement & XMLHttpRequest`.
+ */
 export type XHRWithUrl = HTMLElement &
   XMLHttpRequest & {
     __zone_symbol__xhrURL: string;
@@ -59,6 +63,7 @@ export declare interface WindowWithOcwGlobals extends Window {
    */
   ocSampleRate?: number;
 
-  //
-  ocTraceOrigins?: string;
+  // RegExp to control what origins will the `trace context header` be sent.
+  // That way the header is not added to all xhrs.
+  ocTraceHeaderHostRegex?: string | RegExp;
 }

--- a/packages/opencensus-web-instrumentation-zone/test/test-interaction-tracker.ts
+++ b/packages/opencensus-web-instrumentation-zone/test/test-interaction-tracker.ts
@@ -389,7 +389,7 @@ describe('InteractionTracker', () => {
 
   function doHTTPRequest() {
     // Set the ocTraceOrigins value so the `traceparent` context header is set.
-    (window as WindowWithOcwGlobals).ocTraceOrigins = location.hostname;
+    (window as WindowWithOcwGlobals).ocTraceHeaderHostRegex = /.*/;
     const xhr = new XMLHttpRequest();
     xhr.onreadystatechange = noop;
     spyOn(xhr, 'send').and.callFake(() => {

--- a/packages/opencensus-web-instrumentation-zone/test/test-interaction-tracker.ts
+++ b/packages/opencensus-web-instrumentation-zone/test/test-interaction-tracker.ts
@@ -288,7 +288,7 @@ describe('InteractionTracker', () => {
       'setRequestHeader'
     ).and.callThrough();
     const onclick = () => {
-      doHTTPRequest('http://localhost:8000/test');
+      doHttpRequest('http://localhost:8000/test');
     };
     fakeInteraction(onclick);
 
@@ -302,6 +302,7 @@ describe('InteractionTracker', () => {
 
       expect(rootSpan.spans.length).toBe(1);
       const childSpan = rootSpan.spans[0];
+      // Check the `traceparent` header is not set as Trace Header Host does not match.
       expect(setRequestHeaderSpy).not.toHaveBeenCalled();
       expect(childSpan.name).toBe('/test');
       expect(childSpan.attributes[ATTRIBUTE_HTTP_STATUS_CODE]).toBe('200');
@@ -321,7 +322,7 @@ describe('InteractionTracker', () => {
       'setRequestHeader'
     ).and.callThrough();
     const onclick = () => {
-      doHTTPRequest('http://localhost:8000/test');
+      doHttpRequest('http://localhost:8000/test');
     };
     fakeInteraction(onclick);
 
@@ -361,7 +362,7 @@ describe('InteractionTracker', () => {
       const promise = getPromise();
       promise.then(() => {
         setTimeout(() => {
-          doHTTPRequest();
+          doHttpRequest();
         }, SET_TIMEOUT_TIME);
       });
     };
@@ -423,7 +424,7 @@ describe('InteractionTracker', () => {
     });
   }
 
-  function doHTTPRequest(urlRequest?: string) {
+  function doHttpRequest(urlRequest = '/test') {
     const xhr = new XMLHttpRequest();
     xhr.onreadystatechange = noop;
     spyOn(xhr, 'send').and.callFake(() => {
@@ -433,7 +434,7 @@ describe('InteractionTracker', () => {
         xhr.dispatchEvent(event);
       }, XHR_TIME);
     });
-    if (!urlRequest) urlRequest = '/test';
+
     xhr.open('GET', urlRequest);
     // Spy on `readystate` property after open, so that way while intercepting
     // the XHR will detect OPENED and DONE states.


### PR DESCRIPTION
Intercept XHR tasks, add the `traceparent` context header. Also, creates a child span for every XHR task so that way the client side will have their spans. Final result is shown as follows:
![image](https://user-images.githubusercontent.com/22863695/60906137-7b341f00-a244-11e9-8fa4-5dcca3175d52.png)

In order to add some attributes to the child span like the `HTTP method`, the ` XMLHttpRequest.prototype.open` method is monkey patched.