### PR TITLE
Join browser performance data with the XHR spans

### DIFF
--- a/examples/user_interaction/server/server.js
+++ b/examples/user_interaction/server/server.js
@@ -71,7 +71,9 @@ function handleRequest(request, response) {
     request.on('data', chunk => body.push(chunk));
 
     // Necessary header because the Node.js and React dev servers run in different ports.
-    response.setHeader('Access-Control-Allow-Origin', '*');    
+    response.setHeader('Access-Control-Allow-Origin', '*');
+    // Header to show more info in the span annotations.
+    response.setHeader('Timing-Allow-Origin', '*');
     
     let result = '';
     let code = 200;

--- a/packages/opencensus-web-exporter-ocagent/src/adapters.ts
+++ b/packages/opencensus-web-exporter-ocagent/src/adapters.ts
@@ -27,9 +27,12 @@ const RECENT_EPOCH_MS = 1500000000000; // July 13, 2017.
 /**
  * Converts a RootSpan type from @opencensus/web-core to the Span JSON structure
  * expected by the OpenCensus Agent's HTTP/JSON (grpc-gateway) API.
+ * Also adapts all its descendants.
  */
 export function adaptRootSpan(rootSpan: webCore.RootSpan): apiTypes.Span[] {
-  const adaptedSpans: apiTypes.Span[] = rootSpan.spans.map(adaptSpan);
+  const adaptedSpans: apiTypes.Span[] = rootSpan
+    .allDescendants()
+    .map(span => adaptSpan(span as webCore.Span));
   adaptedSpans.unshift(adaptSpan(rootSpan));
   return adaptedSpans;
 }

--- a/packages/opencensus-web-instrumentation-perf/src/index.ts
+++ b/packages/opencensus-web-instrumentation-perf/src/index.ts
@@ -22,3 +22,5 @@ export {
   getPerfEntries,
   clearPerfEntries,
 } from './perf-grouper';
+export { annotationsForPerfTimeFields } from './util';
+export { PERFORMANCE_ENTRY_EVENTS, getResourceSpan } from './resource-span';

--- a/packages/opencensus-web-instrumentation-perf/src/resource-span.ts
+++ b/packages/opencensus-web-instrumentation-perf/src/resource-span.ts
@@ -19,7 +19,7 @@ import { PerformanceResourceTimingExtended } from './perf-types';
 import { annotationsForPerfTimeFields } from './util';
 
 /** PerformanceEntry time event fields to create as span annotations. */
-const PERFORMANCE_ENTRY_EVENTS = [
+export const PERFORMANCE_ENTRY_EVENTS = [
   'workerStart',
   'fetchStart',
   'domainLookupStart',

--- a/packages/opencensus-web-instrumentation-zone/package.json
+++ b/packages/opencensus-web-instrumentation-zone/package.json
@@ -69,6 +69,7 @@
   "dependencies": {
     "@opencensus/web-core": "^0.0.3",
     "@opencensus/web-exporter-ocagent": "^0.0.3",
+    "@opencensus/web-instrumentation-perf": "0.0.3",
     "@opencensus/web-propagation-tracecontext": "0.0.3"
   },
   "peerDependencies": {

--- a/packages/opencensus-web-instrumentation-zone/src/monkey-patching.ts
+++ b/packages/opencensus-web-instrumentation-zone/src/monkey-patching.ts
@@ -17,13 +17,13 @@
 import { XHRWithUrl } from './zone-types';
 
 export function doPatching() {
-  patchXMLHttpRequestOpen();
+  patchXmlHttpRequestOpen();
 }
 
 // Patch the `XMLHttpRequest.open` method to add method used for the request.
 // This patch is needed because Zone.js does not capture the method from XHR
 // the way that it captures URL as __zone_symbol__xhrURL.
-function patchXMLHttpRequestOpen() {
+function patchXmlHttpRequestOpen() {
   const open = XMLHttpRequest.prototype.open;
 
   XMLHttpRequest.prototype.open = function(

--- a/packages/opencensus-web-instrumentation-zone/src/monkey-patching.ts
+++ b/packages/opencensus-web-instrumentation-zone/src/monkey-patching.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { XHRWithUrl } from './zone-types';
+import { XhrWithUrl } from './zone-types';
 
 export function doPatching() {
   patchXmlHttpRequestOpen();
@@ -38,6 +38,6 @@ function patchXmlHttpRequestOpen() {
     } else {
       open.call(this, method, url, true, null, null);
     }
-    (this as XHRWithUrl)._ocweb_method = method;
+    (this as XhrWithUrl)._ocweb_method = method;
   };
 }

--- a/packages/opencensus-web-instrumentation-zone/src/perf-resource-timing-selector.ts
+++ b/packages/opencensus-web-instrumentation-zone/src/perf-resource-timing-selector.ts
@@ -1,0 +1,164 @@
+/**
+ * Copyright 2019, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Span } from '@opencensus/web-core';
+import { XhrPerformanceResourceTiming } from './zone-types';
+
+/**
+ * Get Browser's performance resource timing data associated to a XHR.
+ * For this case, some XHR might have two or one performance resource
+ * timings as one of them is CORS pre-flight request and the second is related
+ * to the actual HTTP request.
+ * The algorithm to select performance resource timings related to that xhr is
+ * is composed in general by three steps:
+ *
+ * 1. Filter the Performance Resource Timings by the name (it should match the
+ * XHR URL), additionally, the start/end timings of every performance entry
+ * should fit within the span start/end timings. These filtered performance
+ * resource entries are considered as possible entries associated to the xhr.
+ * Those are possible as there might be more than two entries that pass the
+ * filter.
+ *
+ * 2. As the XHR could cause a CORS pre-flight, we have to look for either
+ * possible pairs of performance resource timings or a single performance
+ * resource entry (a possible pair is when a resource timing entry does not
+ * overlap timings with other resource timing entry. Also, a possible single
+ * resource timing is when that resource timing entry is not paired with any
+ * other entry). Thus, for this step traverse the array of possible resource
+ * entries and for every entry try to pair it with the other possible entries.
+ *
+ * 3. Pick the best performance resource timing for the XHR: Using the possible
+ * performance resource timing entries from previous step, the best entry will
+ * be the one with the minimum gap to the span start/end timings. That is the
+ * substraction between the entry `respondeEnd` value and the span
+ * `endPerfTime` plus the substraction between the entry `startTime` and span
+ * `startPerfTime`. In case it is a tuple, the `startTime` corresponds to the
+ * first entry and the `responseEnd` is from second entry.
+ * The performance resource timing entry with the minimum gap to the span
+ * start/end timings points out that entry is the best fit for the span.
+ *
+ * @param xhrUrl
+ * @param span
+ */
+export function getXhrPerfomanceData(
+  xhrUrl: string,
+  span: Span
+): XhrPerformanceResourceTiming | undefined {
+  const filteredPerfEntries = getPerfResourceEntries(xhrUrl, span);
+  const possibleEntries = getPossiblePerfResourceEntries(filteredPerfEntries);
+  const bestEntry = getBestPerfResourceTiming(possibleEntries, span);
+  return bestEntry;
+}
+
+// Get Performance Resource Timings and filter them by matching the XHR url
+// with perfomance entry name. Additionally, the entry's start/end
+// timings must fit with in the span's start/end timings.
+export function getPerfResourceEntries(
+  xhrUrl: string,
+  span: Span
+): PerformanceResourceTiming[] {
+  return performance
+    .getEntriesByType('resource')
+    .filter(entry =>
+      isPerfEntryPartOfXhr(entry as PerformanceResourceTiming, xhrUrl, span)
+    ) as PerformanceResourceTiming[];
+}
+
+export function getPossiblePerfResourceEntries(
+  perfEntries: PerformanceResourceTiming[]
+): XhrPerformanceResourceTiming[] {
+  const possiblePerfEntries = new Array<XhrPerformanceResourceTiming>();
+  const pairedEntries = new Set<PerformanceResourceTiming>();
+  let perfEntry1: PerformanceResourceTiming;
+  let perfEntry2: PerformanceResourceTiming;
+  // As this part of the algorithm traverses the array twice, although,
+  // this array is not big as the performance resource entries is cleared
+  // when there are no more running XHRs.
+  for (let i = 0; i < perfEntries.length; i++) {
+    perfEntry1 = perfEntries[i];
+    // Compare every performance entry with its consecutive perfomance entries.
+    // That way to avoid comparing twice the entries.
+    for (let j = i + 1; j < perfEntries.length; j++) {
+      perfEntry2 = perfEntries[j];
+      if (!overlappingPerfResourceTimings(perfEntry1, perfEntry2)) {
+        // As the entries are not overlapping, that means those timings
+        // are possible perfomance timings related to the XHR.
+        possiblePerfEntries.push([perfEntry1, perfEntry2]);
+        pairedEntries.add(perfEntry1);
+        pairedEntries.add(perfEntry2);
+      }
+    }
+    // If the entry1 couldn't be paired with any other resource timing,
+    // add it as a single resource timing. This is possible because this
+    // single entry might be better that the other possible entries.
+    if (!pairedEntries.has(perfEntry1)) {
+      possiblePerfEntries.push(perfEntry1 as PerformanceResourceTiming);
+    }
+  }
+  return possiblePerfEntries;
+}
+
+// The best Performance Resource Timing Entry is considered the one with the
+// minimum gap the span end/start timings. That way we think that it fits
+// better to the XHR as it is the closest data to the actual XHR.
+function getBestPerfResourceTiming(
+  perfEntries: XhrPerformanceResourceTiming[],
+  span: Span
+): XhrPerformanceResourceTiming | undefined {
+  let minimumGapToSpan = Number.MAX_VALUE;
+  let bestPerfEntry: XhrPerformanceResourceTiming | undefined = undefined;
+  let sumGapsToSpan: number;
+  for (const perfEntry of perfEntries) {
+    // As a Tuple is in the end an Array, check that perfEntry is instance of
+    // Array is enough to know if this value refers to a Tuple.
+    if (perfEntry instanceof Array) {
+      sumGapsToSpan = Math.abs(perfEntry[0].startTime - span.startPerfTime);
+      sumGapsToSpan += Math.abs(perfEntry[1].responseEnd - span.endPerfTime);
+    } else {
+      sumGapsToSpan = Math.abs(perfEntry.responseEnd - span.endPerfTime);
+      sumGapsToSpan += Math.abs(perfEntry.startTime - span.startPerfTime);
+    }
+    // If there is a new minimum gap to the span, update the minimum and pick
+    // the current performance entry as the best at this point.
+    if (sumGapsToSpan < minimumGapToSpan) {
+      minimumGapToSpan = sumGapsToSpan;
+      bestPerfEntry = perfEntry;
+    }
+  }
+  return bestPerfEntry;
+}
+
+function isPerfEntryPartOfXhr(
+  entry: PerformanceResourceTiming,
+  xhrUrl: string,
+  span: Span
+): boolean {
+  return (
+    entry.name === xhrUrl &&
+    entry.startTime >= span.startPerfTime &&
+    entry.responseEnd <= span.endPerfTime
+  );
+}
+
+function overlappingPerfResourceTimings(
+  entry1: PerformanceResourceTiming,
+  entry2: PerformanceResourceTiming
+): boolean {
+  return (
+    Math.min(entry1.responseEnd, entry2.responseEnd) >=
+    Math.max(entry1.startTime, entry2.startTime)
+  );
+}

--- a/packages/opencensus-web-instrumentation-zone/src/perf-resource-timing-selector.ts
+++ b/packages/opencensus-web-instrumentation-zone/src/perf-resource-timing-selector.ts
@@ -26,8 +26,6 @@ import { alreadyAssignedPerfEntries } from './xhr-interceptor';
  * In overall, the algorithm to get this data takes the best fit for the span,
  * this means the closest performance resource timing to the span start/end
  * performance times is the returned value.
- * @param xhrUrl
- * @param span
  */
 export function getXhrPerfomanceData(
   xhrUrl: string,
@@ -50,9 +48,8 @@ export function getXhrPerfomanceData(
  * Those are possible because there might be more than two entries that pass the
  * filter.
  * Additionally, the returned array is sorted by the entries' `startTime` as
- * getEntriesByType() already does it (https://developer.mozilla.org/en-US/docs/Web/API/Performance/getEntriesByType#Return_Value).
- * @param xhrUrl
- * @param span
+ * getEntriesByType() already does it.
+ * (https://developer.mozilla.org/en-US/docs/Web/API/Performance/getEntriesByType#Return_Value).
  */
 export function getPerfSortedResourceEntries(
   xhrUrl: string,
@@ -93,7 +90,7 @@ export function getPossiblePerfResourceEntries(
     possiblePerfEntries.push({ mainRequest: entryI });
     // Compare every performance entry with the perfomance entries in front of
     // it. This is possible as the entries are sorted by the startTime. That
-    // way we to avoid comparing twice the entries and taking the wrong order.
+    // way, we avoid comparing twice the entries and taking the wrong order.
     for (let j = i + 1; j < filteredSortedPerfEntries.length; j++) {
       const entryJ = filteredSortedPerfEntries[j];
       if (isPossibleCorsPair(entryI, entryJ)) {
@@ -115,9 +112,6 @@ export function getPossiblePerfResourceEntries(
  * be the one with the minimum gap to the span start/end timings.
  * The performance resource timing entry with the minimum gap to the span
  * start/end timings points out that entry is the best fit for the span.
- *
- * @param perfEntries
- * @param span
  */
 function getBestPerfResourceTiming(
   perfEntries: XhrPerformanceResourceTiming[],
@@ -169,15 +163,12 @@ function isPerfEntryPartOfXhr(
  * start/end times.
  */
 function isPossibleCorsPair(
-  entry1: PerformanceResourceTiming,
-  entry2: PerformanceResourceTiming
+  maybePreflight: PerformanceResourceTiming,
+  maybeMainRequest: PerformanceResourceTiming
 ): boolean {
-  // To determine if the entries overlap, the minimum responseEnd should be
-  // less than the maximum startTime (e.g. entry1 with startTime = 1 and
-  // responseEnd = 3 and entry2 with startTime = 2 and responseEnd = 4, the
-  // minimum is 3 and the maximum is 2, this tells that the intervals overlap).
-  return (
-    Math.min(entry1.responseEnd, entry2.responseEnd) <
-    Math.max(entry1.startTime, entry2.startTime)
-  );
+  // We can be sure that `maybePreflight` startTime is less than
+  // `maybeMainRequest` startTime because of the sorting done by
+  // `getEntriesByType`. Thus, to check the timings do not overlap, the
+  // maybePreflight.respondeEnd must be less than maybeMainRequest.startTime.
+  return maybePreflight.responseEnd < maybeMainRequest.startTime;
 }

--- a/packages/opencensus-web-instrumentation-zone/src/util.ts
+++ b/packages/opencensus-web-instrumentation-zone/src/util.ts
@@ -27,3 +27,14 @@ export function traceOriginMatchesOrSameOrigin(xhrUrl: string): boolean {
 
   return !!(traceHeaderHostRegex && parsedUrl.host.match(traceHeaderHostRegex));
 }
+
+/**
+ * Whether or not a task is being tracked as part of an interaction.
+ */
+export function isTrackedTask(task: Task): boolean {
+  return !!(
+    task.zone &&
+    task.zone.get('data') &&
+    task.zone.get('data').isTracingZone
+  );
+}

--- a/packages/opencensus-web-instrumentation-zone/src/xhr-interceptor.ts
+++ b/packages/opencensus-web-instrumentation-zone/src/xhr-interceptor.ts
@@ -35,8 +35,9 @@ import {
 
 const TRACEPARENT_HEADER = 'traceparent';
 
-// Map intended to keep track of current XHR objects
-// associated to a span.
+/**
+ * Map intended to keep track of current XHR objects associated to a span.
+ */
 const xhrSpans = new Map<XhrWithUrl, Span>();
 
 // Keeps track of the current xhr tasks that are running. This is
@@ -44,9 +45,11 @@ const xhrSpans = new Map<XhrWithUrl, Span>();
 // xhr tasks are being intercepted.
 let xhrTasksCount = 0;
 
-// Set to keep track of already assigned performance resource entries to a span.
-// This is done as there might be some edge cases where the result might include
-// some already assigned entries.
+/**
+ * Set to keep track of already assigned performance resource entries to a span.
+ * This is done as there might be some edge cases where the result might include
+ * some already assigned entries.
+ */
 export const alreadyAssignedPerfEntries = new Set<PerformanceResourceTiming>();
 
 /**
@@ -55,7 +58,6 @@ export const alreadyAssignedPerfEntries = new Set<PerformanceResourceTiming>();
  * In case the task is intercepted, sets the Trace Context Header to it and
  * creates a child span related to this XHR in case it is OPENED.
  * In case the XHR is DONE, end the child span.
- * @param task
  */
 export function interceptXhrTask(task: AsyncTask) {
   if (!isTrackedTask(task)) return;
@@ -109,9 +111,11 @@ function endXhrSpan(xhr: XhrWithUrl): void {
   }
 }
 
-// If xhr task count is 0, clear the Performance Resource Timings.
-// This is done in order to help the browser Performance resource timings
-// selector algorithm to take only the data related to the current XHRs running.
+/**
+ * If xhr task count is 0, clear the Performance Resource Timings.
+ * This is done in order to help the browser Performance resource timings
+ * selector algorithm to take only the data related to the current XHRs running.
+ */
 function maybeClearPerfResourceBuffer(): void {
   if (xhrTasksCount === 0) {
     performance.clearResourceTimings();

--- a/packages/opencensus-web-instrumentation-zone/src/xhr-interceptor.ts
+++ b/packages/opencensus-web-instrumentation-zone/src/xhr-interceptor.ts
@@ -1,0 +1,151 @@
+/**
+ * Copyright 2019, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { AsyncTask, XHRWithUrl } from './zone-types';
+import {
+  RootSpan,
+  Span,
+  ATTRIBUTE_HTTP_STATUS_CODE,
+  ATTRIBUTE_HTTP_METHOD,
+  parseUrl,
+  SpanKind,
+} from '@opencensus/web-core';
+import { getXhrPerfomanceData } from './perf-resource-timing-selector';
+import { traceOriginMatchesOrSameOrigin, isTrackedTask } from './util';
+import { spanContextToTraceParent } from '@opencensus/web-propagation-tracecontext';
+import {
+  annotationsForPerfTimeFields,
+  PerformanceResourceTimingExtended,
+  PERFORMANCE_ENTRY_EVENTS,
+  getResourceSpan,
+} from '@opencensus/web-instrumentation-perf';
+
+// Map intended to keep track of current XHR objects
+// associated to a span.
+const xhrSpans = new Map<XHRWithUrl, Span>();
+
+// Keeps track of the current xhr tasks that are running. This is
+// useful to clear the Performance Resource Timing entries when no
+// xhr tasks are being intercepted.
+let xhrTasksCount = 0;
+
+/**
+ * Intercepts task as XHR if it is a tracked task and its target object is
+ * instance of `XMLHttpRequest`.
+ * In case the task is intercepted, sets the Trace Context Header to it and
+ * creates a child span related to this XHR in case it is OPENED.
+ * In case the XHR is DONE, end the child span.
+ * @param task
+ */
+export function interceptXhrTask(task: AsyncTask) {
+  if (!isTrackedTask(task)) return;
+  if (!(task.target instanceof XMLHttpRequest)) return;
+
+  const xhr = task.target as XHRWithUrl;
+  if (xhr.readyState === XMLHttpRequest.OPENED) {
+    incrementXhrTaskCount();
+    const rootSpan: RootSpan = task.zone.get('data').rootSpan;
+    setTraceparentContextHeader(xhr, rootSpan);
+  } else if (xhr.readyState === XMLHttpRequest.DONE) {
+    endXhrSpan(xhr);
+    decrementXhrTaskCount();
+  }
+}
+
+function setTraceparentContextHeader(
+  xhr: XHRWithUrl,
+  rootSpan: RootSpan
+): void {
+  // `__zone_symbol__xhrURL` is set by the Zone monkey-path.
+  const xhrUrl = xhr.__zone_symbol__xhrURL;
+  const childSpan = rootSpan.startChildSpan({
+    name: parseUrl(xhrUrl).pathname,
+    kind: SpanKind.CLIENT,
+  });
+  // Associate the child span to the XHR so it allows to
+  // find the correct span when the request is DONE.
+  xhrSpans.set(xhr, childSpan);
+  if (traceOriginMatchesOrSameOrigin(xhrUrl)) {
+    xhr.setRequestHeader(
+      'traceparent',
+      spanContextToTraceParent({
+        traceId: rootSpan.traceId,
+        spanId: childSpan.id,
+      })
+    );
+  }
+}
+
+function endXhrSpan(xhr: XHRWithUrl): void {
+  const span = xhrSpans.get(xhr);
+  if (span) {
+    // TODO: Investigate more to send the the status code a `number` rather
+    // than `string`. Once it is able to send as a number, change it.
+    span.addAttribute(ATTRIBUTE_HTTP_STATUS_CODE, xhr.status.toString());
+    span.addAttribute(ATTRIBUTE_HTTP_METHOD, xhr._ocweb_method);
+    span.end();
+    joinPerfResourceDataToSpan(xhr, span);
+    xhrSpans.delete(xhr);
+  }
+}
+
+// If xhr task count is 0, clear the Performance Resource Timings.
+// This is done in order to help the browser Performance resource timings
+// selector algorithm to take only the data related to the current XHRs running.
+function maybeClearPerfResourceBuffer(): void {
+  if (xhrTasksCount === 0) performance.clearResourceTimings();
+}
+
+function joinPerfResourceDataToSpan(xhr: XHRWithUrl, span: Span) {
+  const perfResourceTimings = getXhrPerfomanceData(xhr.responseURL, span);
+  if (perfResourceTimings instanceof Array) {
+    // This case is true when the resource timings data associates two entries
+    // to the span, where the first entry is the CORS pre-flight request and
+    // the second is the actual HTTP request. Create a child span which is
+    // related to the CORS pre-flight and use the second entry to add
+    // annotations to the span.
+    const corsPerfTiming = perfResourceTimings[0] as PerformanceResourceTimingExtended;
+    const actualXhrPerfTiming = perfResourceTimings[1] as PerformanceResourceTimingExtended;
+    setCorsPerfTimingAsChildSpan(corsPerfTiming, span);
+    span.annotations = annotationsForPerfTimeFields(
+      actualXhrPerfTiming,
+      PERFORMANCE_ENTRY_EVENTS
+    );
+  } else if (perfResourceTimings) {
+    span.annotations = annotationsForPerfTimeFields(
+      perfResourceTimings as PerformanceResourceTimingExtended,
+      PERFORMANCE_ENTRY_EVENTS
+    );
+  }
+}
+
+function setCorsPerfTimingAsChildSpan(
+  performanceTiming: PerformanceResourceTimingExtended,
+  span: Span
+): void {
+  const corsSpan = getResourceSpan(performanceTiming, span.traceId, span.id);
+  corsSpan.name = 'CORS';
+  span.spans.push(corsSpan);
+}
+
+function incrementXhrTaskCount(): void {
+  xhrTasksCount++;
+}
+
+function decrementXhrTaskCount(): void {
+  if (xhrTasksCount > 0) xhrTasksCount--;
+  maybeClearPerfResourceBuffer();
+}

--- a/packages/opencensus-web-instrumentation-zone/src/xhr-interceptor.ts
+++ b/packages/opencensus-web-instrumentation-zone/src/xhr-interceptor.ts
@@ -122,20 +122,18 @@ function maybeClearPerfResourceBuffer(): void {
 
 function joinPerfResourceDataToSpan(xhr: XhrWithUrl, span: Span) {
   const xhrPerfResourceTiming = getXhrPerfomanceData(xhr.responseURL, span);
-  if (xhrPerfResourceTiming) {
-    alreadyAssignedPerfEntries.add(xhrPerfResourceTiming.mainRequest);
-    if (xhrPerfResourceTiming.corsPreFlightRequest) {
-      alreadyAssignedPerfEntries.add(
-        xhrPerfResourceTiming.corsPreFlightRequest
-      );
-      const corsPerfTiming = xhrPerfResourceTiming.corsPreFlightRequest as PerformanceResourceTimingExtended;
-      setCorsPerfTimingAsChildSpan(corsPerfTiming, span);
-    }
-    span.annotations = annotationsForPerfTimeFields(
-      xhrPerfResourceTiming.mainRequest as PerformanceResourceTimingExtended,
-      PERFORMANCE_ENTRY_EVENTS
-    );
+  if (!xhrPerfResourceTiming) return;
+
+  alreadyAssignedPerfEntries.add(xhrPerfResourceTiming.mainRequest);
+  if (xhrPerfResourceTiming.corsPreFlightRequest) {
+    alreadyAssignedPerfEntries.add(xhrPerfResourceTiming.corsPreFlightRequest);
+    const corsPerfTiming = xhrPerfResourceTiming.corsPreFlightRequest as PerformanceResourceTimingExtended;
+    setCorsPerfTimingAsChildSpan(corsPerfTiming, span);
   }
+  span.annotations = annotationsForPerfTimeFields(
+    xhrPerfResourceTiming.mainRequest as PerformanceResourceTimingExtended,
+    PERFORMANCE_ENTRY_EVENTS
+  );
 }
 
 function setCorsPerfTimingAsChildSpan(
@@ -152,6 +150,9 @@ function incrementXhrTaskCount(): void {
 }
 
 function decrementXhrTaskCount(): void {
+  // Check the xhr tasks count should be greater than 0 to avoid do negative
+  // counting. However, this case should never happen, this is just to make
+  // clear it is not possible to happen.
   if (xhrTasksCount > 0) xhrTasksCount--;
   maybeClearPerfResourceBuffer();
 }

--- a/packages/opencensus-web-instrumentation-zone/src/zone-types.ts
+++ b/packages/opencensus-web-instrumentation-zone/src/zone-types.ts
@@ -43,7 +43,7 @@ export interface OnPageInteractionData {
  * `HTMLElement` is necessary when the xhr is captured from the tasks target
  *  as the Zone monkey-patch parses xhrs as `HTMLElement & XMLHttpRequest`.
  */
-export type XHRWithUrl = HTMLElement &
+export type XhrWithUrl = HTMLElement &
   XMLHttpRequest & {
     __zone_symbol__xhrURL: string;
     _ocweb_method: string;
@@ -71,20 +71,10 @@ export declare interface WindowWithOcwGlobals extends Window {
 /**
  * Allows to keep track of performance entries related to a XHR.
  * As some XHRs might generate a CORS pre-flight request, the XHR
- * might have either two performance resource entries or a single
- * performance resource entry.
+ * might have a cors preflight performance resource timing entry or only the
+ * main request performance resource timing.
  */
-export type XhrPerformanceResourceTiming =
-  | PerformanceResourceTimingTuple
-  | PerformanceResourceTiming;
-
-/**
- * Tuple type to associate two `PerformanceResourceTiming` objects as a pair.
- * Used to select performance resource timing data associated to an XHR. In
- * general, the first value points out it is a CORS pre-flight request data and
- * the second value corresponds to the actual HTTP request.
- */
-type PerformanceResourceTimingTuple = [
-  PerformanceResourceTiming,
-  PerformanceResourceTiming
-];
+export interface XhrPerformanceResourceTiming {
+  corsPreFlightRequest?: PerformanceResourceTiming;
+  mainRequest: PerformanceResourceTiming;
+}

--- a/packages/opencensus-web-instrumentation-zone/src/zone-types.ts
+++ b/packages/opencensus-web-instrumentation-zone/src/zone-types.ts
@@ -67,3 +67,24 @@ export declare interface WindowWithOcwGlobals extends Window {
   // That way the header is not added to all xhrs.
   ocTraceHeaderHostRegex?: string | RegExp;
 }
+
+/**
+ * Allows to keep track of performance entries related to a XHR.
+ * As some XHRs might generate a CORS pre-flight request, the XHR
+ * might have either two performance resource entries or a single
+ * performance resource entry.
+ */
+export type XhrPerformanceResourceTiming =
+  | PerformanceResourceTimingTuple
+  | PerformanceResourceTiming;
+
+/**
+ * Tuple type to associate two `PerformanceResourceTiming` objects as a pair.
+ * Used to select performance resource timing data associated to an XHR. In
+ * general, the first value points out it is a CORS pre-flight request data and
+ * the second value corresponds to the actual HTTP request.
+ */
+type PerformanceResourceTimingTuple = [
+  PerformanceResourceTiming,
+  PerformanceResourceTiming
+];

--- a/packages/opencensus-web-instrumentation-zone/test/index.ts
+++ b/packages/opencensus-web-instrumentation-zone/test/index.ts
@@ -18,3 +18,4 @@
 // should import from all test files.
 import './test-on-page-interaction-stop-watch';
 import './test-interaction-tracker';
+import './test-perf-resource-timing-selector';

--- a/packages/opencensus-web-instrumentation-zone/test/test-perf-resource-timing-selector.ts
+++ b/packages/opencensus-web-instrumentation-zone/test/test-perf-resource-timing-selector.ts
@@ -16,7 +16,7 @@
 
 import { Span } from '@opencensus/web-core';
 import {
-  getPerfResourceEntries,
+  getPerfSortedResourceEntries,
   getPossiblePerfResourceEntries,
   getXhrPerfomanceData,
 } from '../src/perf-resource-timing-selector';
@@ -55,7 +55,7 @@ describe('Perf Resource Timing Selector', () => {
       const span = createSpan(12, 30);
 
       const entriesToBeFiltered = [entry2, entry3];
-      const filteredPerfEntries = getPerfResourceEntries('/test', span);
+      const filteredPerfEntries = getPerfSortedResourceEntries('/test', span);
       expect(filteredPerfEntries).toEqual(entriesToBeFiltered);
     });
   });
@@ -92,10 +92,15 @@ describe('Perf Resource Timing Selector', () => {
         mainRequest: entry3,
       } as XhrPerformanceResourceTiming;
 
-      expect(filteredPerfEntries.length).toBe(2);
+      expect(filteredPerfEntries.length).toBe(5);
       expect(filteredPerfEntries).toContain(nonOverlappingEntry1);
       expect(filteredPerfEntries).toContain(nonOverlappingEntry2);
       expect(filteredPerfEntries).not.toContain(overlappingEntry3);
+      // As every entry is considered a possible Xhr performance entry
+      // without CORS preflight, check the should be present.
+      expect(filteredPerfEntries).toContain({ mainRequest: entry1 });
+      expect(filteredPerfEntries).toContain({ mainRequest: entry2 });
+      expect(filteredPerfEntries).toContain({ mainRequest: entry3 });
     });
 
     it('Should not add cors preflight value as all the entries overlap each other', () => {

--- a/packages/opencensus-web-instrumentation-zone/test/test-perf-resource-timing-selector.ts
+++ b/packages/opencensus-web-instrumentation-zone/test/test-perf-resource-timing-selector.ts
@@ -1,0 +1,216 @@
+/**
+ * Copyright 2019, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Span } from '@opencensus/web-core';
+import {
+  getPerfResourceEntries,
+  getPossiblePerfResourceEntries,
+  getXhrPerfomanceData,
+} from '../src/perf-resource-timing-selector';
+import { spyPerfEntryByType, createFakePerfResourceEntry } from './util';
+
+describe('Perf Resource Timing Selector', () => {
+  describe('getPerfResourceEntries', () => {
+    it('Should filter properly the resource entries', () => {
+      // Should ignore this as it has a different name
+      const entry1 = createFakePerfResourceEntry(
+        13.100000011036173,
+        15.100000011036173,
+        '/different_url'
+      );
+      const entry2 = createFakePerfResourceEntry(
+        14.100000011036173,
+        15.200000011036173
+      );
+      const entry3 = createFakePerfResourceEntry(
+        16.100000011036173,
+        18.100000011036173
+      );
+      // Should ignore this even if the end times are close.
+      const entry4 = createFakePerfResourceEntry(
+        20.100000011036173,
+        30.000000000000003
+      );
+      // Ignore this as its out of the span end time.
+      const entry5 = createFakePerfResourceEntry(
+        35.100000011036173,
+        40.100000011036173
+      );
+      const perfResourceEntries = [entry1, entry2, entry3, entry4, entry5];
+      spyPerfEntryByType(perfResourceEntries);
+      const span = createSpan(12, 30);
+
+      const entriesToBeFiltered = [entry2, entry3];
+      const filteredPerfEntries = getPerfResourceEntries('/test', span);
+      expect(filteredPerfEntries).toEqual(entriesToBeFiltered);
+    });
+  });
+
+  describe('getPossiblePerfResourceEntries', () => {
+    it('Should pair no overlapping entries', () => {
+      const entry1 = createFakePerfResourceEntry(
+        2.100000011036173,
+        5.500000011036173
+      );
+      const entry2 = createFakePerfResourceEntry(
+        5.500000011036173,
+        10.200000011036173
+      );
+      const entry3 = createFakePerfResourceEntry(
+        8.200000011036173,
+        15.500000011036173
+      );
+      const entry4 = createFakePerfResourceEntry(
+        13.500000011036173,
+        20.000000000000003
+      );
+      const perfResourceEntries = [entry1, entry2, entry3, entry4];
+      const filteredPerfEntries = getPossiblePerfResourceEntries(
+        perfResourceEntries
+      );
+
+      expect(filteredPerfEntries.length).toBe(3);
+      // Entry1 and entry2 overlap as entry1 startTime is equal to entry2
+      // endTime.
+      expect(filteredPerfEntries).not.toContain([entry1, entry2]);
+      expect(filteredPerfEntries).toContain([entry1, entry3]);
+      expect(filteredPerfEntries).toContain([entry1, entry4]);
+      expect(filteredPerfEntries).not.toContain([entry2, entry3]);
+      expect(filteredPerfEntries).toContain([entry2, entry4]);
+      expect(filteredPerfEntries).not.toContain([entry3, entry4]);
+    });
+
+    it('Should take single resource timing entries', () => {
+      const entry1 = createFakePerfResourceEntry(
+        2.100000011036173,
+        5.500000011036173
+      );
+      const entry2 = createFakePerfResourceEntry(
+        5.500000011036173,
+        10.200000011036173
+      );
+      const entry3 = createFakePerfResourceEntry(
+        1.500000011036173,
+        20.000000000000003
+      );
+      const perfResourceEntries = [entry1, entry2, entry3];
+      const filteredPerfEntries = getPossiblePerfResourceEntries(
+        perfResourceEntries
+      );
+      expect(filteredPerfEntries.length).toBe(3);
+      expect(filteredPerfEntries).toContain(entry1);
+      expect(filteredPerfEntries).toContain(entry2);
+      expect(filteredPerfEntries).toContain(entry3);
+    });
+
+    it('Should take single and tuples of resource timing entries', () => {
+      const entry1 = createFakePerfResourceEntry(
+        2.100000011036173,
+        5.500000011036173
+      );
+      const entry2 = createFakePerfResourceEntry(
+        6.500000011036173,
+        10.200000011036173
+      );
+      const entry3 = createFakePerfResourceEntry(
+        8.500000011036173,
+        20.000000000000003
+      );
+      const entry4 = createFakePerfResourceEntry(
+        1.500000011036173,
+        25.000000000000003
+      );
+      const perfResourceEntries = [entry1, entry2, entry3, entry4];
+      const filteredPerfEntries = getPossiblePerfResourceEntries(
+        perfResourceEntries
+      );
+      expect(filteredPerfEntries.length).toBe(3);
+      expect(filteredPerfEntries).toContain([entry1, entry2]);
+      expect(filteredPerfEntries).toContain([entry1, entry3]);
+      expect(filteredPerfEntries).not.toContain([entry1, entry4]);
+      expect(filteredPerfEntries).not.toContain([entry2, entry3]);
+      expect(filteredPerfEntries).not.toContain([entry2, entry4]);
+      // Should not contain the single resource entries as they already were
+      // paired.
+      expect(filteredPerfEntries).not.toContain(entry1);
+      expect(filteredPerfEntries).not.toContain(entry2);
+      expect(filteredPerfEntries).not.toContain(entry3);
+      // As entry4 has not been paired, should contain this a single entry.
+      expect(filteredPerfEntries).toContain(entry4);
+    });
+  });
+
+  describe('getXhrPerfomanceData', () => {
+    it('Should take the tuple with the minimum gap to the span as the best resource timing entry', () => {
+      const entry1 = createFakePerfResourceEntry(
+        13.100000011036173,
+        15.100000011036173
+      );
+      const entry2 = createFakePerfResourceEntry(
+        13.200000011036173,
+        15.200000011036173
+      );
+      const entry3 = createFakePerfResourceEntry(
+        16.100000011036173,
+        18.100000011036173
+      );
+      const entry4 = createFakePerfResourceEntry(
+        16.200000011036173,
+        18.200000011036173
+      );
+      // Ignore this as its out of the span end time.
+      const entry5 = createFakePerfResourceEntry(
+        35.100000011036173,
+        40.100000011036173
+      );
+      const perfResourceEntries = [entry1, entry2, entry3, entry4, entry5];
+      spyPerfEntryByType(perfResourceEntries);
+      const span = createSpan(13.1, 18.3);
+
+      const filteredPerfEntries = getXhrPerfomanceData('/test', span);
+      expect(filteredPerfEntries).toEqual([entry1, entry4]);
+    });
+
+    it('Should take the single resource entry with the minimum gap to the span as the best entry', () => {
+      const entry1 = createFakePerfResourceEntry(
+        5.100000011036173,
+        20.100000011036173
+      );
+      const entry2 = createFakePerfResourceEntry(
+        10.100000011036173,
+        13.100000011036173
+      );
+      const entry3 = createFakePerfResourceEntry(
+        14.200000011036173,
+        20.000000011036173
+      );
+
+      const perfResourceEntries = [entry1, entry2, entry3];
+      spyPerfEntryByType(perfResourceEntries);
+
+      const span = createSpan(5.1, 20.2);
+      const filteredPerfEntries = getXhrPerfomanceData('/test', span);
+      expect(filteredPerfEntries).toEqual(entry1);
+    });
+  });
+});
+
+function createSpan(startTime: number, endTime: number): Span {
+  const span = new Span();
+  span.startPerfTime = startTime;
+  span.endPerfTime = endTime;
+  return span;
+}

--- a/packages/opencensus-web-instrumentation-zone/test/util.ts
+++ b/packages/opencensus-web-instrumentation-zone/test/util.ts
@@ -1,0 +1,63 @@
+/**
+ * Copyright 2019, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { PerformanceResourceTimingExtended } from '@opencensus/web-instrumentation-perf';
+
+export function createFakePerfResourceEntry(
+  startTime: number,
+  endTime: number,
+  name = '/test'
+): PerformanceResourceTimingExtended {
+  return {
+    connectEnd: 0,
+    connectStart: 0,
+    decodedBodySize: 0,
+    domainLookupEnd: 0,
+    domainLookupStart: 0,
+    duration: endTime - startTime,
+    encodedBodySize: 0,
+    entryType: 'resource',
+    fetchStart: startTime,
+    initiatorType: 'xmlhttprequest',
+    name,
+    nextHopProtocol: 'h2',
+    redirectEnd: 0,
+    redirectStart: 0,
+    redirectCount: 0,
+    requestStart: 0,
+    responseEnd: endTime,
+    responseStart: 0,
+    secureConnectionStart: 0,
+    serverTiming: [],
+    startTime,
+    transferSize: 0,
+    workerStart: 0,
+    toJSON: () => ({}),
+  };
+}
+
+/**
+ * Spies on Performance.getEntriesByType('resoruce') to return the given value
+ * rather than the actual value.
+ */
+export function spyPerfEntryByType(
+  perfResourceEntries: PerformanceResourceTiming[]
+) {
+  spyOn(performance, 'getEntriesByType').and.callFake((entryType: string) => {
+    if (entryType === 'resource') return perfResourceEntries;
+    else return [];
+  });
+}


### PR DESCRIPTION
- Add `perf-resource-timing-selector` module to filter and get the `performance resource timings` related to the XHRs.
- Create a child span associated to the XHR span. This spans refers to the CORS pre-flight request in case the XHR caused this kind of request.
- Add performance data annotations to the XHR span.
- Move the XHR interceptor to a new separate module `xhr-interceptor` which allows a better control of intercepted XHRs and counting the amount of tasks being intercepted currently to clear the performance resource timing buffer.
- Update and add testing.
- Update the `adaptRootSpan` in the exporter agent to adapt all its descendants instead of adapting only its direct children.

This is how the traces look like:
![image](https://user-images.githubusercontent.com/22863695/61237101-af598500-a707-11e9-822c-2c868514fac5.png)

