### PR TITLE
Monkey-Patch `XMLHttpRequest.send()` to send traceparent header and generate XHR span when the this method is called

### DIFF
--- a/packages/opencensus-web-instrumentation-zone/src/monkey-patching.ts
+++ b/packages/opencensus-web-instrumentation-zone/src/monkey-patching.ts
@@ -65,11 +65,21 @@ function patchXmlHttpRequestSend() {
       | ReadableStream<Uint8Array>
       | null
   ) {
-    (this as XhrWithOcWebData)._ocweb_has_called_send = true;
-    const event = new Event('readystatechange');
-    // Dispatch the event before the actual `send` is called, so the readyState
-    // is still OPENED and xhr interceptor will be able to intercept it.
-    this.dispatchEvent(event);
+    setXhrAttributeHasCalledSend(this);
     open.call(this, body);
   };
+}
+
+/**
+ * Function to set attribute in the XHR that points out `send()` has been
+ * called and dispatch the event before the actual `send` is called, then, the
+ * readyState is still OPENED and xhr interceptor will be able to intercept it.
+ *
+ * This is exported to be called in testing as we want to avoid calling the
+ * actual XHR's `send()`.
+ */
+export function setXhrAttributeHasCalledSend(xhr: XMLHttpRequest) {
+  (xhr as XhrWithOcWebData)._ocweb_has_called_send = true;
+  const event = new Event('readystatechange');
+  xhr.dispatchEvent(event);
 }

--- a/packages/opencensus-web-instrumentation-zone/src/xhr-interceptor.ts
+++ b/packages/opencensus-web-instrumentation-zone/src/xhr-interceptor.ts
@@ -65,7 +65,6 @@ export function interceptXhrTask(task: AsyncTask) {
   if (!(task.target instanceof XMLHttpRequest)) return;
 
   const xhr = task.target as XhrWithOcWebData;
-  console.log(xhr.readyState);
   if (xhr.readyState === XMLHttpRequest.OPENED && xhr._ocweb_has_called_send) {
     // Only generate the XHR and send the tracer if it is OPENED and the
     // `send()` method has beend called.

--- a/packages/opencensus-web-instrumentation-zone/src/xhr-interceptor.ts
+++ b/packages/opencensus-web-instrumentation-zone/src/xhr-interceptor.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { AsyncTask, XhrWithUrl } from './zone-types';
+import { AsyncTask, XhrWithOcWebData } from './zone-types';
 import {
   RootSpan,
   Span,
@@ -38,7 +38,7 @@ const TRACEPARENT_HEADER = 'traceparent';
 /**
  * Map intended to keep track of current XHR objects associated to a span.
  */
-const xhrSpans = new Map<XhrWithUrl, Span>();
+const xhrSpans = new Map<XhrWithOcWebData, Span>();
 
 // Keeps track of the current xhr tasks that are running. This is
 // useful to clear the Performance Resource Timing entries when no
@@ -56,15 +56,24 @@ export const alreadyAssignedPerfEntries = new Set<PerformanceResourceTiming>();
  * Intercepts task as XHR if it is a tracked task and its target object is
  * instance of `XMLHttpRequest`.
  * In case the task is intercepted, sets the Trace Context Header to it and
- * creates a child span related to this XHR in case it is OPENED.
+ * creates a child span related to this XHR in case it is OPENED and `send()`
+ * has been called.
  * In case the XHR is DONE, end the child span.
  */
 export function interceptXhrTask(task: AsyncTask) {
   if (!isTrackedTask(task)) return;
   if (!(task.target instanceof XMLHttpRequest)) return;
 
-  const xhr = task.target as XhrWithUrl;
-  if (xhr.readyState === XMLHttpRequest.OPENED) {
+  const xhr = task.target as XhrWithOcWebData;
+  console.log(xhr.readyState);
+  if (xhr.readyState === XMLHttpRequest.OPENED && xhr._ocweb_has_called_send) {
+    // Only generate the XHR and send the tracer if it is OPENED and the
+    // `send()` method has beend called.
+    // This avoids associating the wrong performance resource timing entries
+    // to the XHR when `send()` is not called right after `open()` is called.
+    // This is because there might be a long gap between `open()` and `send()`
+    // methods are called, and within this gap there might be other HTTP
+    // requests causing more entries to the Performance Resource buffer.
     incrementXhrTaskCount();
     const rootSpan: RootSpan = task.zone.get('data').rootSpan;
     setTraceparentContextHeader(xhr, rootSpan);
@@ -75,7 +84,7 @@ export function interceptXhrTask(task: AsyncTask) {
 }
 
 function setTraceparentContextHeader(
-  xhr: XhrWithUrl,
+  xhr: XhrWithOcWebData,
   rootSpan: RootSpan
 ): void {
   // `__zone_symbol__xhrURL` is set by the Zone monkey-path.
@@ -98,7 +107,7 @@ function setTraceparentContextHeader(
   }
 }
 
-function endXhrSpan(xhr: XhrWithUrl): void {
+function endXhrSpan(xhr: XhrWithOcWebData): void {
   const span = xhrSpans.get(xhr);
   if (span) {
     // TODO: Investigate more to send the the status code a `number` rather
@@ -124,7 +133,7 @@ function maybeClearPerfResourceBuffer(): void {
   }
 }
 
-function joinPerfResourceDataToSpan(xhr: XhrWithUrl, span: Span) {
+function joinPerfResourceDataToSpan(xhr: XhrWithOcWebData, span: Span) {
   const xhrPerfResourceTiming = getXhrPerfomanceData(xhr.responseURL, span);
   if (!xhrPerfResourceTiming) return;
 

--- a/packages/opencensus-web-instrumentation-zone/src/zone-types.ts
+++ b/packages/opencensus-web-instrumentation-zone/src/zone-types.ts
@@ -39,14 +39,18 @@ export interface OnPageInteractionData {
 }
 
 /**
- * Allows monkey-patching XMLHttpRequest and to obtain the request URL.
+ * Allows monkey-patching XMLHttpRequest and obtain important data for
+ * OpenCensus Web such as the request URL or the HTTP method.
  * `HTMLElement` is necessary when the xhr is captured from the tasks target
  *  as the Zone monkey-patch parses xhrs as `HTMLElement & XMLHttpRequest`.
  */
-export type XhrWithUrl = HTMLElement &
+export type XhrWithOcWebData = HTMLElement &
   XMLHttpRequest & {
     __zone_symbol__xhrURL: string;
     _ocweb_method: string;
+    // Attribute to tell that `send()` method has been called before it sends
+    // any HTTP request.
+    _ocweb_has_called_send: boolean;
   };
 
 /** Type for `window` object with variables OpenCensus Web interacts with. */


### PR DESCRIPTION
I found out a bug in the xhr-interceptor when the XHR span is generated and the browser performance data is joined to the XHR span. The XHR span was being started when the XHR is in OPENED state (`open()` method is called), however, the http requests that the XHR generates are only done when the `send()` method is called. The problem here is that the method `send()` could be called a long time after  `open()` is called. This means that there might be a big gap between `open()` and `send()` calls, and within this gap, there might be requests from other interactions calling to the same URL, this will generate a wrong result in the performance resource timing selector, as those entries could have a better fit in the span.

The solution then is to monkey-patch `XMLHttpRequest.send()` to send the traceparent header and generate the XHR span when the this method is called, but before the HTTP requests are done.
This means that the Performance entries should fit almost exactly in the span's start/end times and the XHR span will actually measure the time taken by the XHR.