### PR TITLE
Relate user interaction traces back to the initial page load trace

### DIFF
--- a/packages/opencensus-web-core/src/trace/model/attribute-keys.ts
+++ b/packages/opencensus-web-core/src/trace/model/attribute-keys.ts
@@ -89,3 +89,8 @@ export const LONG_TASK_PREFIX = 'long_task.';
  * long task.
  */
 export const ATTRIBUTE_LONG_TASK_ATTRIBUTION = `${LONG_TASK_PREFIX}attribution`;
+
+/**
+ * Attribute for spans to be related back to the initial load trace.
+ */
+export const ATTRIBUTE_INITIAL_LOAD_TRACE_ID = 'initial_load_trace_id';

--- a/packages/opencensus-web-instrumentation-perf/src/initial-load-root-span.ts
+++ b/packages/opencensus-web-instrumentation-perf/src/initial-load-root-span.ts
@@ -20,6 +20,7 @@ import {
   ATTRIBUTE_HTTP_USER_AGENT,
   ATTRIBUTE_LONG_TASK_ATTRIBUTION,
   ATTRIBUTE_NAV_TYPE,
+  ATTRIBUTE_INITIAL_LOAD_TRACE_ID,
   parseUrl,
   randomSpanId,
   randomTraceId,
@@ -92,6 +93,7 @@ export function getInitialLoadRootSpan(
   root.annotations = getNavigationAnnotations(perfEntries);
   root.attributes[ATTRIBUTE_HTTP_URL] = navigationUrl;
   root.attributes[ATTRIBUTE_HTTP_USER_AGENT] = navigator.userAgent;
+  root.attributes[ATTRIBUTE_INITIAL_LOAD_TRACE_ID] = root.traceId;
 
   if (navTiming) {
     root.endPerfTime = navTiming.loadEventEnd;

--- a/packages/opencensus-web-instrumentation-perf/src/initial-load-root-span.ts
+++ b/packages/opencensus-web-instrumentation-perf/src/initial-load-root-span.ts
@@ -93,6 +93,8 @@ export function getInitialLoadRootSpan(
   root.annotations = getNavigationAnnotations(perfEntries);
   root.attributes[ATTRIBUTE_HTTP_URL] = navigationUrl;
   root.attributes[ATTRIBUTE_HTTP_USER_AGENT] = navigator.userAgent;
+  // This is included to enable trace search by attribute to find an initial
+  // load trace and its interaction traces via a single attribute query.
   root.attributes[ATTRIBUTE_INITIAL_LOAD_TRACE_ID] = root.traceId;
 
   if (navTiming) {

--- a/packages/opencensus-web-instrumentation-perf/test/test-initial-load-root-span.ts
+++ b/packages/opencensus-web-instrumentation-perf/test/test-initial-load-root-span.ts
@@ -128,6 +128,7 @@ const EXPECTED_ROOT_ATTRIBUTES: Attributes = {
   'http.url': 'http://localhost:4200/',
   'http.user_agent': USER_AGENT,
   'nav.type': 'navigate',
+  initial_load_trace_id: '0000000000000000000000000000000b',
 };
 const EXPECTED_ROOT_ANNOTATIONS: Annotation[] = [
   {

--- a/packages/opencensus-web-instrumentation-zone/src/on-page-interaction-stop-watch.ts
+++ b/packages/opencensus-web-instrumentation-zone/src/on-page-interaction-stop-watch.ts
@@ -19,7 +19,10 @@ import {
   ATTRIBUTE_HTTP_URL,
   ATTRIBUTE_HTTP_USER_AGENT,
   ATTRIBUTE_HTTP_PATH,
+  ATTRIBUTE_INITIAL_LOAD_TRACE_ID,
+  LinkType,
 } from '@opencensus/web-core';
+import { getInitialLoadSpanContext } from '@opencensus/web-initial-load';
 
 /** A helper class for tracking on page interactions. */
 export class OnPageInteractionStopwatch {
@@ -44,7 +47,8 @@ export class OnPageInteractionStopwatch {
   }
 
   /**
-   * Stops the stopwatch, fills root span attributes and ends the span.
+   * Stops the stopwatch. Adds root span attributes and link to the initial
+   * load page, also, ends the span.
    * If has remaining tasks do not end the root span.
    */
   stopAndRecord(): void {
@@ -56,6 +60,16 @@ export class OnPageInteractionStopwatch {
     rootSpan.addAttribute(ATTRIBUTE_HTTP_URL, this.data.startLocationHref);
     rootSpan.addAttribute(ATTRIBUTE_HTTP_PATH, this.data.startLocationPath);
     rootSpan.addAttribute(ATTRIBUTE_HTTP_USER_AGENT, navigator.userAgent);
+    const initialLoadSpanContext = getInitialLoadSpanContext();
+    rootSpan.addAttribute(
+      ATTRIBUTE_INITIAL_LOAD_TRACE_ID,
+      initialLoadSpanContext.traceId
+    );
+    rootSpan.addLink(
+      initialLoadSpanContext.traceId,
+      initialLoadSpanContext.spanId,
+      LinkType.CHILD_LINKED_SPAN
+    );
     rootSpan.end();
   }
 }

--- a/packages/opencensus-web-instrumentation-zone/src/on-page-interaction-stop-watch.ts
+++ b/packages/opencensus-web-instrumentation-zone/src/on-page-interaction-stop-watch.ts
@@ -61,6 +61,8 @@ export class OnPageInteractionStopwatch {
     rootSpan.addAttribute(ATTRIBUTE_HTTP_PATH, this.data.startLocationPath);
     rootSpan.addAttribute(ATTRIBUTE_HTTP_USER_AGENT, navigator.userAgent);
     const initialLoadSpanContext = getInitialLoadSpanContext();
+    // This is included to enable trace search by attribute to find an initial
+    // load trace and its interaction traces via a single attribute query.
     rootSpan.addAttribute(
       ATTRIBUTE_INITIAL_LOAD_TRACE_ID,
       initialLoadSpanContext.traceId
@@ -68,7 +70,7 @@ export class OnPageInteractionStopwatch {
     rootSpan.addLink(
       initialLoadSpanContext.traceId,
       initialLoadSpanContext.spanId,
-      LinkType.CHILD_LINKED_SPAN
+      LinkType.PARENT_LINKED_SPAN
     );
     rootSpan.end();
   }

--- a/packages/opencensus-web-instrumentation-zone/test/test-interaction-tracker.ts
+++ b/packages/opencensus-web-instrumentation-zone/test/test-interaction-tracker.ts
@@ -51,7 +51,7 @@ describe('InteractionTracker', () => {
     {
       traceId: INITIAL_LOAD_TRACE_ID,
       spanId: INITIAL_LOAD_SPAN_ID,
-      type: LinkType.CHILD_LINKED_SPAN,
+      type: LinkType.PARENT_LINKED_SPAN,
       attributes: {},
     },
   ];

--- a/packages/opencensus-web-instrumentation-zone/test/test-on-page-interaction-stop-watch.ts
+++ b/packages/opencensus-web-instrumentation-zone/test/test-on-page-interaction-stop-watch.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { RootSpan, Tracer } from '@opencensus/web-core';
+import { RootSpan, Tracer, WindowWithOcwGlobals } from '@opencensus/web-core';
 import { OnPageInteractionStopwatch } from '../src/on-page-interaction-stop-watch';
 
 describe('OnPageInteractionStopWatch', () => {
@@ -21,6 +21,7 @@ describe('OnPageInteractionStopWatch', () => {
   let tracer: Tracer;
   let interaction: OnPageInteractionStopwatch;
   let target: HTMLElement;
+  const windowWithOcwGlobals = window as WindowWithOcwGlobals;
 
   describe('Tasks tracking', () => {
     beforeEach(() => {
@@ -53,6 +54,9 @@ describe('OnPageInteractionStopWatch', () => {
   });
 
   describe('stopAndRecord()', () => {
+    const traceId = '0af7651916cd43dd8448eb211c80319c';
+    const spanId = 'b7ad6b7169203331';
+    windowWithOcwGlobals.traceparent = `00-${traceId}-${spanId}-01`;
     beforeEach(() => {
       tracer = Tracer.instance;
       root = new RootSpan(tracer, { name: 'root1' });
@@ -72,6 +76,7 @@ describe('OnPageInteractionStopWatch', () => {
 
       expect(root.attributes['EventType']).toBe('click');
       expect(root.attributes['TargetElement']).toBe(target.tagName);
+      expect(root.attributes['initial_load_trace_id']).toBe(traceId);
       expect(tracer.onEndSpan).toHaveBeenCalledWith(root);
     });
     it('Should not finish the interaction when there are remaining tasks', () => {

--- a/packages/opencensus-web-instrumentation-zone/test/test-on-page-interaction-stop-watch.ts
+++ b/packages/opencensus-web-instrumentation-zone/test/test-on-page-interaction-stop-watch.ts
@@ -13,7 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { RootSpan, Tracer, WindowWithOcwGlobals } from '@opencensus/web-core';
+import {
+  RootSpan,
+  Tracer,
+  WindowWithOcwGlobals,
+  LinkType,
+} from '@opencensus/web-core';
 import { OnPageInteractionStopwatch } from '../src/on-page-interaction-stop-watch';
 
 describe('OnPageInteractionStopWatch', () => {
@@ -77,6 +82,14 @@ describe('OnPageInteractionStopWatch', () => {
       expect(root.attributes['EventType']).toBe('click');
       expect(root.attributes['TargetElement']).toBe(target.tagName);
       expect(root.attributes['initial_load_trace_id']).toBe(traceId);
+      expect(root.links).toEqual([
+        {
+          traceId,
+          spanId,
+          type: LinkType.PARENT_LINKED_SPAN,
+          attributes: {},
+        },
+      ]);
       expect(tracer.onEndSpan).toHaveBeenCalledWith(root);
     });
     it('Should not finish the interaction when there are remaining tasks', () => {


### PR DESCRIPTION
- Add `initia_load_trace_id` to every the user interaction root spans and the initial load root span. This allows the customer to search all traces related to a whole navigation through the initial page.
- Add a link to the initial load trace so the customers can easily go back to the initial trace.

Here is an example on how the user interaction trace looks like:
![image](https://user-images.githubusercontent.com/22863695/61957138-91ecac80-af8c-11e9-8e5b-47469bb58f89.png)
