### PR TITLE
Fix schedule and cancel task patch

### DIFF
--- a/packages/opencensus-web-instrumentation-zone-peer-dep/src/util.ts
+++ b/packages/opencensus-web-instrumentation-zone-peer-dep/src/util.ts
@@ -31,12 +31,8 @@ export function traceOriginMatchesOrSameOrigin(xhrUrl: string): boolean {
 /**
  * Whether or not a task is being tracked as part of an interaction.
  */
-export function isTrackedTask(task: Task): boolean {
-  return !!(
-    task.zone &&
-    task.zone.get('data') &&
-    task.zone.get('data').isTracingZone
-  );
+export function isTracingZone(zone: Zone): boolean {
+  return !!(zone && zone.get('data') && zone.get('data').isTracingZone);
 }
 
 /**

--- a/packages/opencensus-web-instrumentation-zone-peer-dep/src/xhr-interceptor.ts
+++ b/packages/opencensus-web-instrumentation-zone-peer-dep/src/xhr-interceptor.ts
@@ -24,7 +24,7 @@ import {
   SpanKind,
 } from '@opencensus/web-core';
 import { getXhrPerfomanceData } from './perf-resource-timing-selector';
-import { traceOriginMatchesOrSameOrigin, isTrackedTask } from './util';
+import { traceOriginMatchesOrSameOrigin, isTracingZone } from './util';
 import { spanContextToTraceParent } from '@opencensus/web-propagation-tracecontext';
 import {
   annotationsForPerfTimeFields,
@@ -61,7 +61,7 @@ export const alreadyAssignedPerfEntries = new Set<PerformanceResourceTiming>();
  * In case the XHR is DONE, end the child span.
  */
 export function interceptXhrTask(task: AsyncTask) {
-  if (!isTrackedTask(task)) return;
+  if (!isTracingZone(task.zone)) return;
   if (!(task.target instanceof XMLHttpRequest)) return;
 
   const xhr = task.target as XhrWithOcWebData;


### PR DESCRIPTION
This fixes the patch in `scheduleTask` and `cancelTask` to call the actual functions with the current Zone and avoid calling exceptions when the `zone` and the `task.zone` are different.