### PR TITLE
Add package.json metadata for ES6 module imports

### DIFF
--- a/packages/opencensus-web-types/package.json
+++ b/packages/opencensus-web-types/package.json
@@ -30,6 +30,7 @@
   "engines": {
     "node": ">=6.0"
   },
+  "type": "module",
   "files": [
     "build/src/**/*.js",
     "build/src/**/*.d.ts",


### PR DESCRIPTION
In Azure/azure-sdk-for-js#9060 bterlson wrote: 

> Additionally, @opencensus/web-types doesn't have the correct package.json metadata to contain ES6 module imports.

I have no experience in ES6 modules (it's not available in any LTS version of NodeJS), so please kindly careful reviews.